### PR TITLE
Make link absolute

### DIFF
--- a/docs/guides/deploy-guide/manager.md
+++ b/docs/guides/deploy-guide/manager.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 # Manager
 
 The prerequisite for the deployment of the Manager is the preparation of a
-[configuration repository](../../getting-started/configuration-repository.md).
+[configuration repository](https://osism.github.io/docs/getting-started/configuration-repository).
 
 1. Install Ubuntu 22.04 on the node to be used as manager
    (see [Provisioning of management and control plane nodes](./bootstrap.md##provisioning-of-management-and-control-plane-nodes)).


### PR DESCRIPTION
Guides ([guides](https://osism.github.io/docs/guides/) & [advanced guides](https://osism.github.io/docs/advanced-guides/)) that will be consumed by the [SCS Documentation ](https://docs.scs.community) should be absolute as relative links cannot be resolved if the paths are not within the imported paths. 

This PR fixes only one link to the configuration. 

Currently blocks building SCS Docs: https://github.com/SovereignCloudStack/docs/pull/115