### PR TITLE
testbed: fix syntax in the webinterfaces table

### DIFF
--- a/docs/guides/deploy-guide/examples/testbed.md
+++ b/docs/guides/deploy-guide/examples/testbed.md
@@ -336,25 +336,25 @@ If you want to access the services please choose the URL from the following tabl
 
 | **Name**                 | **URL**                                        | **Username** | **Password** | **Note**        |
 |--------------------------|------------------------------------------------|--------------|--------------|-----------------|
-| ARA                      | <https://ara.testbed.osism.xyz/>                 | ara          | password     |                 |
-| Ceph                     | <https://api-int.testbed.osism.xyz:8140>         | admin        | password     |                 |
-| Flower                   | <https://flower.testbed.osism.xyz>               |              |              |                 |
-| Grafana                  | <https://api-int.testbed.osism.xyz:3000>         | admin        | password     |                 |
-| HAProxy (testbed-node-0) | <http://testbed-node-0.testbed.osism.xyz:1984>   | haproxy      | password     |                 |
-| HAProxy (testbed-node-1) | <http://testbed-node-1.testbed.osism.xyz:1984>   | haproxy      | password     |                 |
-| HAProxy (testbed-node-2) | <http://testbed-node-2.testbed.osism.xyz:1984>   | haproxy      | password     |                 |
-| Homer                    | <https://homer.testbed.osism.xyz>                |              |              |                 |
-| Horizon (via Keycloak)   | <https://api.testbed.osism.xyz>                  | alice        | password     |                 |
-| Horizon (via Keystone)   | <https://api.testbed.osism.xyz>                  | admin        | password     | domain: default |
-| Horizon (via Keystone)   | <https://api.testbed.osism.xyz>                  | test         | test         | domain: test    |
-| Keycloak                 | <https://keycloak.testbed.osism.xyz/auth>        | admin        | password     |                 |
-| Netbox                   | <https://netbox.testbed.osism.xyz/>              | admin        | password     |                 |
-| Netdata                  | <http://testbed-manager.testbed.osism.xyz:19999> |              |              |                 |
-| Nexus                    | <https://nexus.testbed.osism.xyz/>               | admin        | password     |                 |
-| OpenSearch Dashboards    | <https://api.testbed.osism.xyz:5601>             | opensearch   | password     |                 |
-| Prometheus               | <https://api-int.testbed.osism.xyz:9091/>        |              |              |                 |
-| RabbitMQ                 | <https://api-int.testbed.osism.xyz:15672/>       | openstack    | password     |                 |
-| phpMyAdmin               | <https://phpmyadmin.testbed.osism.xyz>           | root         | password     |                 |
+| ARA                      | https://ara.testbed.osism.xyz                  | ara          | password     |                 |
+| Ceph                     | https://api-int.testbed.osism.xyz:8140         | admin        | password     |                 |
+| Flower                   | https://flower.testbed.osism.xyz               |              |              |                 |
+| Grafana                  | https://api-int.testbed.osism.xyz:3000         | admin        | password     |                 |
+| HAProxy (testbed-node-0) | http://testbed-node-0.testbed.osism.xyz:1984   | haproxy      | password     |                 |
+| HAProxy (testbed-node-1) | http://testbed-node-1.testbed.osism.xyz:1984   | haproxy      | password     |                 |
+| HAProxy (testbed-node-2) | http://testbed-node-2.testbed.osism.xyz:1984   | haproxy      | password     |                 |
+| Homer                    | https://homer.testbed.osism.xyz                |              |              |                 |
+| Horizon (via Keycloak)   | https://api.testbed.osism.xyz                  | alice        | password     |                 |
+| Horizon (via Keystone)   | https://api.testbed.osism.xyz                  | admin        | password     | domain: default |
+| Horizon (via Keystone)   | https://api.testbed.osism.xyz                  | test         | test         | domain: test    |
+| Keycloak                 | https://keycloak.testbed.osism.xyz/auth        | admin        | password     |                 |
+| Netbox                   | https://netbox.testbed.osism.xyz               | admin        | password     |                 |
+| Netdata                  | http://testbed-manager.testbed.osism.xyz:19999 |              |              |                 |
+| Nexus                    | https://nexus.testbed.osism.xyz                | admin        | password     |                 |
+| OpenSearch Dashboards    | https://api.testbed.osism.xyz:5601             | opensearch   | password     |                 |
+| Prometheus               | https://api-int.testbed.osism.xyz:9091         |              |              |                 |
+| RabbitMQ                 | https://api-int.testbed.osism.xyz:15672        | openstack    | password     |                 |
+| phpMyAdmin               | https://phpmyadmin.testbed.osism.xyz           | root         | password     |                 |
 
 ### Authentication with OIDC
 


### PR DESCRIPTION
Looks like the <...> are not working like expected:

Unexpected character `/` (U+002F) before local name, expected a character that can start a name, such as a letter, `$`, or `_` (note: to create a link in MDX, use `[text](url)`)

Related to 7b7aa7feb7352b0244270b4f590cd2ab65866dd2