### PR TITLE
Change haproxy_user in testbed documentation

### DIFF
--- a/docs/guides/other-guides/testbed.mdx
+++ b/docs/guides/other-guides/testbed.mdx
@@ -393,9 +393,9 @@ If you want to access the services please choose the URL from the following tabl
 | Ceph                     | https://api-int.testbed.osism.xyz:8140         | admin        | password     |                 |
 | Flower                   | https://flower.testbed.osism.xyz               |              |              |                 |
 | Grafana                  | https://api-int.testbed.osism.xyz:3000         | admin        | password     |                 |
-| HAProxy (testbed-node-0) | http://testbed-node-0.testbed.osism.xyz:1984   | haproxy      | password     |                 |
-| HAProxy (testbed-node-1) | http://testbed-node-1.testbed.osism.xyz:1984   | haproxy      | password     |                 |
-| HAProxy (testbed-node-2) | http://testbed-node-2.testbed.osism.xyz:1984   | haproxy      | password     |                 |
+| HAProxy (testbed-node-0) | http://testbed-node-0.testbed.osism.xyz:1984   | openstack    | password     |                 |
+| HAProxy (testbed-node-1) | http://testbed-node-1.testbed.osism.xyz:1984   | openstack    | password     |                 |
+| HAProxy (testbed-node-2) | http://testbed-node-2.testbed.osism.xyz:1984   | openstack    | password     |                 |
 | Homer                    | https://homer.testbed.osism.xyz                |              |              |                 |
 | Horizon (via Keycloak)   | https://api.testbed.osism.xyz                  | alice        | password     |                 |
 | Horizon (via Keystone)   | https://api.testbed.osism.xyz                  | admin        | password     | domain: default |


### PR DESCRIPTION
The `haproxy_user` defaults to 'openstack' ([1]).

[1]
https://github.com/osism/defaults/blob/main/all/001-kolla-defaults.yml#L972