### PR TITLE
remove incorrect procedure (#647)

### DIFF
--- a/docs/guides/deploy-guide/services/openstack.md
+++ b/docs/guides/deploy-guide/services/openstack.md
@@ -116,10 +116,6 @@ Not all of the services listed there are supported by OSISM.
 
     The secret is added to the secure.yml file. The password is set in the parameter
     `octavia_keystone_password` in the file `environments/kolla/secrets.yml`.
-    ```
-    make ansible_vault_edit FILE=/opt/configuration/environments/openstack/secure.yml
-    git add -f /opt/configuration/environments/openstack/secure.yml
-    ```
 
     Get the secret with
     ```


### PR DESCRIPTION
The procedure was accidentally introduced with commit 3843cde6d9c724cd08034b1ef13389e2a47dcb9c
where the motivation was that we can support a encrypted secure.yml. 
Missed another command in the previous request.