### PR TITLE
Adapt to current behaviour of cepchclient installation

### DIFF
--- a/docs/guides/configuration-guide/rook.md
+++ b/docs/guides/configuration-guide/rook.md
@@ -45,7 +45,7 @@ After successfully configuring the environment for the client, run the installat
 osism apply cephclient
 ```
 
-TODO: This will try to detect a prior installation of a Ceph client with the install type `container` or `package` and cleanup that.
+This will try to detect a prior installation of a Ceph client with the install type `container` or `package` and cleanup that previous installation.
 
 
 


### PR DESCRIPTION
To reflect the changes made to the installation of the cephclient this change was made.
A new type of the cehpclient (`rook`) is introduced and when set the installation of the cephclient will utilise the tolling provided by Rook and checks if there is a previous installation of cephclient wrappers (`package` or `container`). If that is the case the previous installation is properly cleaned up before installing the new wrapper scripts appropriate to the Rook environment.

[osism/issues/886](https://github.com/osism/issues/issues/886)
[osism/issues/1038](https://github.com/osism/issues/issues/1038)