### PR TITLE
upgrade-guide: ansible vault auto detect works for OSISM >= 8.0.0

### DIFF
--- a/docs/guides/upgrade-guide/manager.mdx
+++ b/docs/guides/upgrade-guide/manager.mdx
@@ -82,7 +82,7 @@ In the example, OSISM release 7.0.5 is used.
    ```
 
    * If Ansible Vault was used to encrypt `environments/manager/secrets.yml`, the parameter
-     `--ask-vault-pass` is also appended. From OSISM >= 7.0.5 this is no longer necessary.
+     `--ask-vault-pass` is also appended. From OSISM >= 8.0.0 this is no longer necessary.
    * If `osism update manager` does not work yet, use `osism-update-manager` instead.
 
 


### PR DESCRIPTION
Related to osism/issues#1130