### PR TITLE
deploy-guide: remove examples

### DIFF
--- a/docs/guides/deploy-guide/examples/cloud-in-a-box.md
+++ b/docs/guides/deploy-guide/examples/cloud-in-a-box.md
@@ -1,9 +1,0 @@
----
-sidebar_label: Cloud in a Box
----
-
-# Cloud in a Box
-
-This section has moved. You can now find the content in the
-[Other Guides](../../other-guides) as
-[Cloud in a Box Guide](../../other-guides/cloud-in-a-box).

--- a/docs/guides/deploy-guide/examples/index.md
+++ b/docs/guides/deploy-guide/examples/index.md
@@ -1,5 +1,0 @@
----
-sidebar_label: Examples
----
-
-# Examples

--- a/docs/guides/deploy-guide/examples/testbed.md
+++ b/docs/guides/deploy-guide/examples/testbed.md
@@ -1,9 +1,0 @@
----
-sidebar_label: Testbed
----
-
-# Testbed
-
-This section has moved. You can now find the content in the
-[Other Guides](../../other-guides/index.md) as
-[Testbed Guide](../../other-guides/testbed/).


### PR DESCRIPTION
The examples are only pointers to the Testbed & Cloud in a Box guides.