### PR TITLE
update 'Getting started' docs defining what stands for OSISM

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ sidebar_position: 10
 
 # Getting started
 
-OSISM is a comprehensive platform for managing software-defined cloud infrastructure that goes far beyond being a simple deployment tool for OpenStack. While OSISM does support the deployment and management of OpenStack as a key component, its capabilities extend to orchestrating a wide array of services and tools needed to build and operate a modern private cloud. By leveraging OSISM, organizations gain a powerful toolset for building, managing, and scaling private cloud infrastructures tailored to their specific needs, while also maintaining full control over their data and operations.
+OSISM stands for Open-Source Infrastructure Services Management. It's a comprehensive platform for managing software-defined cloud infrastructure that goes far beyond being a simple deployment tool for OpenStack. While OSISM does support the deployment and management of OpenStack as a key component, its capabilities extend to orchestrating a wide array of services and tools needed to build and operate a modern private cloud. By leveraging OSISM, organizations gain a powerful toolset for building, managing, and scaling private cloud infrastructures tailored to their specific needs, while also maintaining full control over their data and operations.
 
 ## Guides
 


### PR DESCRIPTION
by merging this request we:

  * start the very first section of the documentation defining what stands for OSISM;
  * fix the "Getting started" by introducing the meaning behind OSISM right away.

new comers should not take longer to be presented with that definition.