### PR TITLE
github: fix deploy workflow permission to contents:write

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     permissions:
-      deployments: write
+      contents: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6


### PR DESCRIPTION
Change the deploy job permission from deployments:write to contents:write, which is required for the deployment to function correctly.

Related to 2aa372d2cf2fcc758b569e60db86e9bc7c3a0075