### PR TITLE
Clean up navbar and footer links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -99,16 +99,6 @@ const config = {
             position: 'left',
             label: 'Documentation',
           },
-          {
-            href: 'https://osism.cloud/de/partner',
-            label: 'Users',
-            position: 'left',
-          },
-          {
-	    href: 'mailto:info@osism.tech?subject=OSISM Demo',
-            label: 'Schedule a demo',
-            position: 'right',
-          },
         ],
       },
       footer: {
@@ -122,7 +112,7 @@ const config = {
                 href: '/docs',
               },
               {
-                label: 'Users',
+                label: 'Partner',
                 href: 'https://osism.cloud/de/partner',
               },
 	    ],


### PR DESCRIPTION
Remove unused "Users" and "Schedule a demo" links from the navbar and rename "Users" to "Partner" in the footer.