### PR TITLE
Replace deprecated gateway4 with routes syntax in netplan examples

### DIFF
--- a/docs/guides/configuration-guide/configuration-repository.md
+++ b/docs/guides/configuration-guide/configuration-repository.md
@@ -208,7 +208,9 @@ as manager in your own cluster.
     eno1:
       addresses:
         - "192.168.16.10/20"
-      gateway4: "192.168.16.1"
+      routes:
+        - to: default
+          via: "192.168.16.1"
       mtu: 1500
   ```
 
@@ -331,7 +333,9 @@ as manager in your own cluster.
     eno1:
       addresses:
         - "192.168.16.10/20"
-      gateway4: "192.168.16.1"
+      routes:
+        - to: default
+          via: "192.168.16.1"
       mtu: 1500
   ```
 


### PR DESCRIPTION
The gateway4 key is deprecated in netplan and causes errors on Ubuntu 24.04. Use the routes syntax instead, consistent with the network configuration guide. (osism/issues#1334)

Closes osism/issues#1334

AI-assisted: Claude Code