### PR TITLE
docs: rename cfg-generics -> generics in guides

### DIFF
--- a/docs/guides/configuration-guide/manager.mdx
+++ b/docs/guides/configuration-guide/manager.mdx
@@ -48,8 +48,8 @@ In the example, OSISM release 7.0.5 is used.
    ```
 
    Optionally, this is normally not necessary, it is possible to reference a specific tag of the
-   [osism/cfg-generics](https://github.com/osism/cfg-generics) repository. To do this, first
-   check which version of osism/cfg-generics is used in a particular release. The version is
+   [osism/generics](https://github.com/osism/generics) repository. To do this, first
+   check which version of osism/generics is used in a particular release. The version is
    defined in `generics_version` in the `base.yml` file in the `osism/release` repository. For OSISM 6.0.0,
    for example, this is version [v0.20230919.0](https://github.com/osism/release/blob/main/6.0.0/base.yml#L6).
    This version is then added to the file `gilt.yml` in the configuration repository instead of

--- a/docs/guides/developer-guide/index.md
+++ b/docs/guides/developer-guide/index.md
@@ -28,7 +28,7 @@ of `osism.services.cgit`.
 |:-----------------------------------------------------------------------------------|:----------------------------------------------------------------------|
 | Add the Ansible role in one of the Ansible collection repositories                 | https://github.com/osism/ansible-collection-services/pull/578/files   |
 | Add the Ansible playbook                                                           | https://github.com/osism/ansible-playbooks/pull/215/files             |
-| Add the Ansible inventory group                                                    | https://github.com/osism/cfg-generics/pull/225/files                  |
+| Add the Ansible inventory group                                                    | https://github.com/osism/generics/pull/225/files                      |
 | Add the used container image(s) to the release repository                          | https://github.com/osism/release/pull/278/files                       |
 | Add the container images(s) to osism-ansible container image                       | https://github.com/osism/container-image-osism-ansible/pull/215/files |
 | Add the container image registry/registries and host(s) to the defaults repository | https://github.com/osism/defaults/pull/54/files                       |

--- a/docs/guides/developer-guide/releases.md
+++ b/docs/guides/developer-guide/releases.md
@@ -272,7 +272,7 @@ other:
 
 ### Example
 
-Here is an example of a [commit from the osism/cfg-generics repository](https://github.com/osism/cfg-generics/commit/e2f04a9f4a51eb058446d7a8ab6835df53989099).
+Here is an example of a [commit from the osism/generics repository](https://github.com/osism/generics/commit/e2f04a9f4a51eb058446d7a8ab6835df53989099).
 
 ```yaml
 ---

--- a/docs/guides/developer-guide/scripts.md
+++ b/docs/guides/developer-guide/scripts.md
@@ -18,7 +18,7 @@ of targets depends on the container it is run in.
 
 * For the `inventory-reconciler` container
   * `/change.sh osism <git branch>` for the [osism/python-osism](https://github.com/osism/python-osism) repository
-  * `/change.sh generics <git branch>` for the [osism/cfg-generics](https://github.com/osism/cfg-generics) repository
+  * `/change.sh generics <git branch>` for the [osism/generics](https://github.com/osism/generics) repository
   * `/change.sh defaults <git branch>` for the [osism/defaults](https://github.com/osism/defaults) repository
   * `/change.sh release <git branch>` for the [osism/release](https://github.com/osism/release) repository
 

--- a/docs/guides/developer-guide/zuul.md
+++ b/docs/guides/developer-guide/zuul.md
@@ -358,7 +358,7 @@ remove the two hanging jobs from the screenshot.
 
 ```bash
 zuul-client --use-config osism dequeue --pipeline periodic-daily --project osism/k8s-capi-images --ref refs/heads/main
-zuul-client --use-config osism dequeue --pipeline periodic-daily --project osism/cfg-generics --ref refs/heads/main
+zuul-client --use-config osism dequeue --pipeline periodic-daily --project osism/generics --ref refs/heads/main
 ```
 
 ## Important daily CI jobs

--- a/docs/guides/upgrade-guide/manager.mdx
+++ b/docs/guides/upgrade-guide/manager.mdx
@@ -52,8 +52,8 @@ In the example, OSISM release 7.0.5 is used.
         ```
 
         Optionally, this is normally not necessary, it is possible to reference a specific tag of the
-        [osism/cfg-generics](https://github.com/osism/cfg-generics) repository. To do this, first
-        check which version of osism/cfg-generics is used in a particular release. The version is
+        [osism/generics](https://github.com/osism/generics) repository. To do this, first
+        check which version of osism/generics is used in a particular release. The version is
         defined in `generics_version` in the `base.yml` file in the `osism/release` repository. For OSISM 6.0.0,
         for example, this is version [v0.20230919.0](https://github.com/osism/release/blob/main/6.0.0/base.yml#L6).
         This version is then added to the file `gilt.yml` in the configuration repository instead of


### PR DESCRIPTION
## Summary
- `osism/cfg-generics` was renamed to `osism/generics`. Update six user-facing guide files: configuration/upgrade `manager.mdx`, `developer-guide/{index.md, releases.md, scripts.md, zuul.md}`.
- Historical release notes (`release-notes/osism-7.md`) are deliberately left untouched — they document the state at release time.
- GitHub's rename alias keeps the old URLs working, so this is prose consistency, not a link fix.

## Test plan
- [ ] Docs build passes
- [ ] Spot-check rendered pages — affected sections read cleanly and links work