### PR TITLE
actions: automatically add all opened issues and PRs to project board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,29 @@
+name: Add issues and PRs to project boards
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+permissions: read-all
+
+jobs:
+  add-to-project-boards:
+    name: Add issues and PRs to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # latest main
+        with:
+          project-url: https://github.com/orgs/osism/projects/20
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: renovate
+          label-operator: NOT
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # latest main
+        with:
+          project-url: https://github.com/orgs/osism/projects/21
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: renovate
+          label-operator: AND


### PR DESCRIPTION
* this action should run whenever issues or PRs are opened and should add them to the "Issues and PRs" project board
* upstream action: https://github.com/actions/add-to-project
* the latest release of the action i currently v1.0.2 from mid 2024 so we can't really use this here to pin the version, but instead reference by commit (currently latest from main)