### PR TITLE
cookiecutter: update registry path from quay.io to registry.osism.tech

### DIFF
--- a/docs/guides/configuration-guide/configuration-repository.md
+++ b/docs/guides/configuration-guide/configuration-repository.md
@@ -63,7 +63,7 @@ listed there will be queried during the execution of Cookiecutter.
      -e TARGET_UID="$(id -u)" \
      -e TARGET_GID="$(id -g)" \
      -v $(pwd)/output:/output \
-     --rm -it quay.io/osism/cookiecutter
+     --rm -it registry.osism.tech/osism/cookiecutter
    ```
 
 3. A few parameters are requested. The parameters are documented in detail in the [parameter reference](#parameter-reference).


### PR DESCRIPTION
* we do not use quay.io to host our images anymore, but are pushing them directly to registry.osism.tech
* to work with a recent version of the cookiecutter, it needs to be pulled from registry.osism.tech/osism/cookiecutter instead of quay.io/osism/cookiecutter

Fixes: #979