### PR TITLE
megalinter: disable zizmor and osv-scanner

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -24,6 +24,8 @@ DISABLE_LINTERS:
   - REPOSITORY_SYFT # not needed
   - SPELL_CSPELL # replaced by codespell
 
+ACTION_ZIZMOR_ARGUMENTS: --no-online-audits
+
 SHOW_ELAPSED_TIME: true
 # Uncomment if you want MegaLinter to detect errors but not block CI to pass
 # DISABLE_ERRORS: true

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -17,6 +17,7 @@ APPLY_FIXES: none
 DISABLE_LINTERS:
   - COPYPASTE_JSCPD # we copy paste a lot of things to keep pages easy to read
   - CSS_STYLELINT # we focus on the documentation for now
+  - ACTION_ZIZMOR # workflows use mutable tags; pinning to SHAs not adopted yet
   - REPOSITORY_GITLEAKS # avoid false positives in documentation repo
   - REPOSITORY_GRYPE # not needed
   - REPOSITORY_TRIVY # not needed
@@ -24,8 +25,6 @@ DISABLE_LINTERS:
   - REPOSITORY_OSV_SCANNER # static site: all npm deps are build-time only, no server exposure
   - REPOSITORY_SYFT # not needed
   - SPELL_CSPELL # replaced by codespell
-
-ACTION_ZIZMOR_ARGUMENTS: --no-online-audits
 
 SHOW_ELAPSED_TIME: true
 # Uncomment if you want MegaLinter to detect errors but not block CI to pass

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -21,6 +21,7 @@ DISABLE_LINTERS:
   - REPOSITORY_GRYPE # not needed
   - REPOSITORY_TRIVY # not needed
   - REPOSITORY_TRIVY_SBOM # not needed
+  - REPOSITORY_OSV_SCANNER # static site: all npm deps are build-time only, no server exposure
   - REPOSITORY_SYFT # not needed
   - SPELL_CSPELL # replaced by codespell
 


### PR DESCRIPTION
## Summary

MegaLinter v9.5.0 added two new linters to the documentation flavor that both fail immediately. This PR disables both.

**zizmor** (added to `DISABLE_LINTERS`): The offline audits report 29 errors — primarily unpinned-uses across all four workflow files (actions referenced by mutable tags like `@v6`, `@v9` rather than pinned SHAs), plus artipacked and secrets-inherit findings. Pinning all action references to SHAs is the correct long-term fix but has not been adopted in this repo and would require ongoing Renovate configuration. Disabling is consistent with the low security risk profile of a static documentation site.

**osv-scanner** (added to `DISABLE_LINTERS`): Found 19 CVEs in `yarn.lock`, but every affected package is a build-time or dev-time tool (webpack, postcss, babel, webpack-dev-server, etc.). None are bundled into the compiled static output served via GitHub Pages. The deployed site has no server-side code and no runtime npm exposure — same rationale as the already-disabled grype, trivy, and syft scanners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)