### PR TITLE
Add OSSA-2026-015 security advisory for Keystone

### DIFF
--- a/docs/appendix/security/index.md
+++ b/docs/appendix/security/index.md
@@ -30,3 +30,4 @@ handling of security-related information.
 | [OSSA-2026-001](ossa-2026-001.md) | Privilege Escalation via Identity Headers in OAuth2   | OpenStack keystonemiddleware |
 | [OSSA-2026-002](ossa-2026-002.md) | Nova calls qemu-img without format restrictions       | OpenStack Nova               |
 | [OSSA-2026-005](ossa-2026-005.md) | Restricted app credentials can create EC2 credentials | OpenStack Keystone           |
+| [OSSA-2026-015](ossa-2026-015.md) | Credential delegation and authorization bypass issues | OpenStack Keystone           |

--- a/docs/appendix/security/ossa-2026-015.md
+++ b/docs/appendix/security/ossa-2026-015.md
@@ -1,0 +1,184 @@
+---
+sidebar_label: OSSA-2026-015
+---
+
+# OSSA-2026-015: Multiple credential delegation and authorization bypass vulnerabilities in Keystone
+
+| Property         | Value                                                                                                                              |
+|:-----------------|:-----------------------------------------------------------------------------------------------------------------------------------|
+| Date             | 2026-05-28                                                                                                                         |
+| CVE              | CVE-2026-42998, CVE-2026-42999, CVE-2026-43000, CVE-2026-43001, CVE-2026-44394                                                     |
+| Severity         | High                                                                                                                               |
+| Affected Project | Keystone                                                                                                                           |
+| Reporter         | Boris Bobrov (SAP SE), Tim Shepherd (roiai.ca), Erichen (Institute of Computing Technology, CAS), Artem Goncharov (SysEleven GmbH) |
+
+## Summary
+
+A set of five related vulnerabilities was discovered in OpenStack Keystone affecting credential
+delegation and authorization enforcement. An authenticated attacker can inject RBAC policy
+targets via the JSON request body to bypass authorization on policy-protected endpoints, read
+credential secrets, create credentials for arbitrary users, and escalate to cloud admin
+(CVE-2026-42999). Application credential authentication does not verify that the caller owns the
+credential, enabling user impersonation within a shared project (CVE-2026-42998), which can be
+chained with trusts to escalate from member to admin (CVE-2026-43000). Application credentials
+scoped to one project can create EC2 credentials for a different project, enabling cross-project
+lateral movement (CVE-2026-43001). Federated users can maintain access indefinitely by repeatedly
+rescoping tokens before expiry (CVE-2026-44394).
+
+**All Keystone deployments are affected.** CVE-2026-44394 only affects deployments using SAML2 or
+OIDC federation.
+
+## Affected Versions
+
+| Keystone Version                         | Status                            |
+|:-----------------------------------------|:----------------------------------|
+| >= 14.0.0, < 28.0.0 (Caracal, Dalmatian) | Vulnerable — EOL, no official fix |
+| >= 28.0.0, < 28.0.2 (Epoxy)              | Vulnerable                        |
+| >= 28.0.2 (Epoxy)                        | Fixed (upstream)                  |
+| >= 29.0.0, < 29.0.2 (Flamingo)           | Vulnerable                        |
+| >= 29.0.2 (Flamingo)                     | Fixed (upstream)                  |
+
+Caracal (2024.1) and Dalmatian (2024.2) have reached end of life upstream. No official fixed
+release exists for either; the only fixes available are community-curated backports.
+
+OSISM ships container images with the fixes backported as downstream patches for the OpenStack
+releases 2024.1 (Caracal), 2024.2 (Dalmatian), 2025.1 (Epoxy), and 2025.2 (Flamingo). Because both
+Caracal and Dalmatian are end of life and receive no official upstream patches, the OSISM images
+for these two releases carry community-curated backports rather than upstream-released fixes.
+
+## Impact on OSISM
+
+**Unlike most credential-related advisories, this issue is not limited to specific
+configurations: every OSISM deployment running an unpatched Keystone version is affected.** There
+is no configuration that makes a deployment immune to CVE-2026-42998, CVE-2026-42999,
+CVE-2026-43000, and CVE-2026-43001.
+
+CVE-2026-44394 additionally affects you only if you use federated authentication (SAML2 or OIDC).
+
+### How to Check if You Are Affected
+
+#### Check the Running Keystone Version
+
+```bash
+docker exec keystone keystone-manage --version 2>/dev/null || \
+  docker exec keystone pip show keystone 2>/dev/null | grep -i version
+```
+
+If the version is below the fixed version for your release (see the table above) and you have not
+deployed an OSISM container image that includes the fix, your deployment is **affected**.
+
+#### Check for Federation (CVE-2026-44394 only)
+
+Check whether SAML2 or OIDC federation is configured:
+
+```bash
+docker exec keystone grep -rE "saml2|openid|mod_auth_openidc|mellon" \
+  /etc/keystone/keystone.conf /etc/apache2/ /etc/httpd/ 2>/dev/null
+```
+
+If no results are returned, your deployment is **not affected** by CVE-2026-44394 (but remains
+affected by the other four CVEs).
+
+## Vulnerability Details
+
+### CVE-2026-42999 — RBAC policy bypass via JSON body and query filters
+
+The RBAC enforcer unconditionally merged the raw JSON request body into the policy enforcement
+dictionary after trusted target data had been set from the database. An attacker could include a
+`target` key in the JSON body to overwrite database-sourced RBAC target attributes, causing all
+`%(target.*)s` policy substitutions to evaluate against attacker-controlled values. This affected
+88 endpoint/method combinations across all Keystone API resources and allows reading credential
+secrets, creating credentials for arbitrary users, and escalation to cloud admin. Query-string
+filter values had the same structural issue (e.g. an attacker-controlled `?user_id=` could
+override an ownership check). The fix namespaces user-controlled body and filter data under
+`request_body` and `filter_attr` keys so they can no longer collide with internal keys.
+
+### CVE-2026-42998 — User impersonation through application credentials
+
+When authenticating by application credential ID, the caller could supply a `user` field in the
+payload. The credential owner was only used when no `user` field was present; if present, the
+resulting token was attributed to the caller-supplied user instead of the credential owner,
+enabling impersonation of an arbitrary user within a shared project. The fix always binds the
+token to the credential's stored `user_id`, ignoring any caller-supplied value.
+
+### CVE-2026-43000 — Trust operations through application credentials
+
+Previously only restricted application credentials were blocked, and only for trust creation and
+deletion. All application credentials (restricted and unrestricted alike) are now blocked from all
+trust operations. Combined with the impersonation flaw, the prior behavior allowed escalation from
+member to admin, with the resulting trust persisting independently of the application credential.
+
+### CVE-2026-43001 — Cross-project EC2 credential creation
+
+`POST /v3/credentials` did not validate that the caller-supplied `project_id` for an EC2-type
+credential matched the project of the authenticating application credential. An attacker holding
+an unrestricted application credential for project A could create an EC2 credential targeting
+project B; a subsequent `/v3/ec2tokens` exchange would then issue a Keystone token scoped to
+project B while still carrying the original `app_cred_id`, enabling cross-project lateral movement
+within the credential owner's role footprint. (CVSS 3.1 base score 7.9, High.)
+
+### CVE-2026-44394 — Federated token rescoping extends session indefinitely
+
+When a federated token was rescoped via `POST /v3/auth/tokens`, Keystone issued a fresh full-TTL
+token instead of inheriting the remaining lifetime of the original token. A user with a federated
+token could extend their session indefinitely by rescoping repeatedly before expiry, bypassing
+operator-configured TTL policies and IdP-level account revocation. The fix propagates the original
+token's `expires_at` so the rescoped token inherits the original expiry. This issue only affects
+SAML2/OIDC deployments.
+
+## Remediation
+
+### For OSISM Releases
+
+The fixes are provided for the Keystone container image via the following change:
+
+- [container-images-kolla commit 134fb90](https://github.com/osism/container-images-kolla/commit/134fb9054b6df596018e4a75321dfab582a639a1)
+  ([PR #731](https://github.com/osism/container-images-kolla/pull/731))
+
+A fix will be included in upcoming OSISM releases that ship the patched Keystone container image.
+Consult the [OSISM Release Notes](../../release-notes/) for version information and availability.
+
+Alternatively, you can use rolling tags to override the Keystone container image with a version
+that includes the fix. Configure the following in `environments/kolla/images.yml`:
+
+```yaml
+keystone_tag: "2025.1"  # or "2024.1", "2024.2", "2025.2", depending on your OpenStack release
+```
+
+:::warning
+
+The fix for CVE-2026-42999 modifies the trust policy structure. Deployments with **customized
+trust policies** may experience issues with image upload and Heat service functionality until the
+custom policy is updated. Review any trust policy overrides before and after applying the patched
+image.
+
+:::
+
+### Mitigation
+
+Because all deployments are affected and the vulnerabilities require only authenticated access,
+applying the patched container image is the only effective remediation. Until the fix is deployed,
+consider the following measures:
+
+1. Restricting network access to OpenStack API endpoints to trusted networks
+2. Monitoring for suspicious credential, trust, and EC2 credential creation activity
+3. Auditing existing application credentials, trusts, and EC2 credentials for unexpected entries
+4. For federated deployments, monitoring for unusually long-lived sessions and repeated token
+   rescoping
+
+## References
+
+- [OSSA-2026-015 Advisory](https://security.openstack.org/ossa/OSSA-2026-015.html)
+- [OSISM Fix (container-images-kolla commit 134fb90)](https://github.com/osism/container-images-kolla/commit/134fb9054b6df596018e4a75321dfab582a639a1)
+- [OSISM Fix (container-images-kolla PR #731)](https://github.com/osism/container-images-kolla/pull/731)
+- [Launchpad Bug #2148398](https://bugs.launchpad.net/keystone/+bug/2148398)
+- [Launchpad Bug #2148477](https://bugs.launchpad.net/keystone/+bug/2148477)
+- [Launchpad Bug #2149775](https://bugs.launchpad.net/keystone/+bug/2149775)
+- [Launchpad Bug #2149789](https://bugs.launchpad.net/keystone/+bug/2149789)
+- [Launchpad Bug #2150089](https://bugs.launchpad.net/keystone/+bug/2150089)
+- [Launchpad Bug #2150379](https://bugs.launchpad.net/keystone/+bug/2150379)
+- [CVE-2026-42998](https://www.cve.org/CVERecord?id=CVE-2026-42998)
+- [CVE-2026-42999](https://www.cve.org/CVERecord?id=CVE-2026-42999)
+- [CVE-2026-43000](https://www.cve.org/CVERecord?id=CVE-2026-43000)
+- [CVE-2026-43001](https://www.cve.org/CVERecord?id=CVE-2026-43001)
+- [CVE-2026-44394](https://www.cve.org/CVERecord?id=CVE-2026-44394)

--- a/docs/guides/migration-guide/cephadm/index.md
+++ b/docs/guides/migration-guide/cephadm/index.md
@@ -928,7 +928,7 @@ appear for any daemon type, some daemons were not adopted with the correct conta
 ## Step 7: Clean up ceph-ansible artifacts
 
 Only proceed with this step after completing the verification in
-[Step 7](#step-7-verify-the-migration): `ceph -s` shows `HEALTH_OK`, all daemons
+[Step 6](#step-6-verify-the-migration): `ceph -s` shows `HEALTH_OK`, all daemons
 appear as `running` in `ceph orch ps`, and `ceph versions` reports a single consistent
 version across all daemon types.
 


### PR DESCRIPTION
## Summary

- Add `docs/appendix/security/ossa-2026-015.md` documenting the five Keystone credential delegation and authorization bypass vulnerabilities published as [OSSA-2026-015](https://security.openstack.org/ossa/OSSA-2026-015.html): CVE-2026-42998, CVE-2026-42999, CVE-2026-43000, CVE-2026-43001, CVE-2026-44394.
- Note that, unlike the previous credential advisories, **all** OSISM deployments are affected (CVE-2026-44394 only with SAML2/OIDC federation).
- Reference the OSISM fix shipped in the keystone container image ([container-images-kolla commit 134fb90](https://github.com/osism/container-images-kolla/commit/134fb9054b6df596018e4a75321dfab582a639a1), [PR #731](https://github.com/osism/container-images-kolla/pull/731)).
- Link the new advisory from the security index.

## Test plan

- [ ] `ossa-2026-015.md` renders correctly (tables, `:::warning` admonition, links)
- [ ] New row appears under "OpenStack Security Advisories (OSSA)" in the index