### PR TITLE
Replace typographic quotes with straight ASCII

### DIFF
--- a/docs/concepts/components/clusterapi.md
+++ b/docs/concepts/components/clusterapi.md
@@ -21,7 +21,7 @@ for managing the lifecycle of Kubernetes clusters.
   Kubernetes clusters, including provisioning, scaling, upgrading, and deletion. This consistency
   reduces operational overhead and ensures that clusters are managed uniformly across different
   environments.
-* Extensibility and Customization: Cluster API’s modular architecture allows for extensibility
+* Extensibility and Customization: Cluster API's modular architecture allows for extensibility
   through the use of custom resource definitions (CRDs) and controllers. Organizations can tailor
   the API to meet specific requirements, such as integrating with existing CI/CD pipelines or
   adding custom operational logic.

--- a/docs/concepts/components/ironic.md
+++ b/docs/concepts/components/ironic.md
@@ -19,7 +19,7 @@ Key benefits of OpenStack Ironic:
 * Support for Multiple Hardware Drivers: Ironic supports a wide range of hardware through
   various drivers, including IPMI, Redfish, and vendor-specific drivers. This flexibility
   ensures compatibility with a diverse set of hardware platforms and management interfaces.
-* Resource Management and Scheduling: Ironic leverages OpenStack’s scheduling capabilities
+* Resource Management and Scheduling: Ironic leverages OpenStack's scheduling capabilities
   to manage the allocation of physical servers, ensuring optimal utilization of hardware
   resources. Users can request specific hardware configurations and Ironic will match these
   requests with available resources.

--- a/docs/concepts/components/openstack.md
+++ b/docs/concepts/components/openstack.md
@@ -3,7 +3,7 @@
 ## Lifecycle Management of OpenStack in OSISM
 
 The open source project Kolla from the [OpenInfra Foundation](https://openinfra.dev) is
-used in OSISM for the life cycle management of OpenStack. Kolla’s mission is to provide
+used in OSISM for the life cycle management of OpenStack. Kolla's mission is to provide
 production-ready containers and deployment tools for operating OpenStack clouds. Kolla has
 been actively developed by a very diverse team for 10 years and is one of the most common
 (if not the most common) life cycle management tool for OpenStack.

--- a/docs/guides/configuration-guide/loadbalancer.md
+++ b/docs/guides/configuration-guide/loadbalancer.md
@@ -148,7 +148,7 @@ by the [general procedure](#general-procedure) described above.
 
 5. Execute all steps in the [general procedure](#general-procedure) above
 
-### Generating TLS certificates with Let’s Encrypt
+### Generating TLS certificates with Let's Encrypt
 
 Using Let's encrypt certificates is a good alternative to traditional certificate authorities and
 greatly simplifies the administration of TLS certificates.

--- a/docs/guides/configuration-guide/openstack/index.md
+++ b/docs/guides/configuration-guide/openstack/index.md
@@ -446,7 +446,7 @@ The number of workers used for the individual services can generally be configur
 
 ```yaml
 openstack_service_workers: "{{ [ansible_facts.processor_vcpus, 5] | min }}"
-openstack_service_rpc_workers: "{{ [ansible_facts.processor_vcpus, 3] | min }}“
+openstack_service_rpc_workers: "{{ [ansible_facts.processor_vcpus, 3] | min }}"
 ```
 
 The default for `openstack_service_workers` is set to `5` when using the cookiecutter for the initial creation

--- a/docs/guides/operations-guide/ceph/index.md
+++ b/docs/guides/operations-guide/ceph/index.md
@@ -334,7 +334,7 @@ Interesting fields:
 
 ### Remove a OSD
 
-As with ‘Remove a single OSD node’. Except that the steps are only executed
+As with 'Remove a single OSD node'. Except that the steps are only executed
 for a single OSD and the node is not removed from the CRUSH map and the inventory.
 Only the entries relating to the removed OSD are removed from the host vars.
 

--- a/docs/guides/operations-guide/network.md
+++ b/docs/guides/operations-guide/network.md
@@ -58,7 +58,7 @@ $ openstack --os-cloud admin image list -f yaml
 
 These UUIDs are great for uniqueness, but 36-character strings are terrible
 for readability. Statistically, just the first few characters are enough for
-uniqueness in small environments, so let’s define a helper to make things more
+uniqueness in small environments, so let's define a helper to make things more
 readable:
 
 ```bash


### PR DESCRIPTION
Replaces typographic (curly) quote characters with straight ASCII equivalents across the built docs, for consistency.

- One commit per category:
  - `config-guide: fix curly quote in rpc_workers YAML` — a left double quote (U+201C) had replaced the closing `"` in a YAML example, making the snippet invalid.
  - `ops-guide: use straight quotes around OSD reference` — curly single quotes (U+2018/U+2019) around a section reference in the Ceph guide.
  - `docs: use straight apostrophes in prose contractions` — curly apostrophes (U+2019) in "Kolla's", "Cluster API's", "OpenStack's", "Let's Encrypt", "let's define".

Note: the `'logs in'` fix in `deploy-guide/manager.md` lives on the separate `fix-apostrophes` branch and is intentionally not duplicated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)