### PR TITLE
Add workflow to publish documentation via FTP

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish via FTP
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  publish:
+    name: Publish via FTP
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build website
+        run: yarn build
+      # Popular action to deploy via FTP:
+      # Docs: https://github.com/SamKirkland/FTP-Deploy-Action
+      - name: Publish via FTP
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        with:
+          server: ${{ secrets.FTP_HOSTNAME }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          protocol: ftps
+          # Build output to publish:
+          local-dir: ./build/
+          server-dir: /


### PR DESCRIPTION
## Summary

Adds a new `publish` workflow that builds the documentation and uploads the result to an FTPS server.

- Triggers on push to `main` and manual `workflow_dispatch`
- Builds the docs (`yarn install` + `yarn build`)
- Publishes the `./build` directory via FTPS using [`SamKirkland/FTP-Deploy-Action`](https://github.com/SamKirkland/FTP-Deploy-Action)

## Configuration

The following repository secrets need to be set under **Settings → Secrets and variables → Actions**:

- `FTP_HOSTNAME` — FTP server host
- `FTP_USERNAME` — FTP user
- `FTP_PASSWORD` — FTP password

Protocol is `ftps` and the target directory on the server is `/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)