### PR TITLE
Run MegaLinter only on pull requests

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -3,12 +3,8 @@
 ---
 name: MegaLinter
 
-# Trigger mega-linter at every push. Action will also be visible from
-# Pull Requests to main
+# Trigger mega-linter only on pull requests (not after a merge to main)
 on:
-  # Comment this line to trigger action only on pull-requests
-  # (not recommended if you don't pay for GH Actions)
-  push:
   pull_request:
 
 # Comment env block if you do not want to apply fixes


### PR DESCRIPTION
MegaLinter was triggered on every `push`, including merges to `main`. This restricts the trigger to `pull_request` only, so it no longer runs after a merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)