### PR TITLE
upgrade-guide: manager update for seed-container deploys

### DIFF
--- a/docs/guides/upgrade-guide/manager.mdx
+++ b/docs/guides/upgrade-guide/manager.mdx
@@ -37,6 +37,23 @@ how you deployed the cluster. Steps 1, 2 and 4 to 6 are the same for all of them
 
   This reuses the same seed tooling as the initial bootstrap, so the manager
   itself needs no local Ansible installation.
+* **Manager deployed with the seed container, seed discarded** (the manager has
+  no local Ansible venv and no seed node remains): run the update from the
+  configuration repository on the manager itself. `run.sh` ships in the repository
+  and is refreshed by `make sync` (step 1), so it does not depend on the manager's
+  installed tooling. With a container engine present and no local venv it runs the
+  playbook inside the `osism/seed` container automatically (`SEED_CONTAINER=auto`):
+
+    ```bash
+    cd /opt/configuration/environments/manager
+    ./run.sh manager
+    ```
+
+  The vault password must be reachable — ship `environments/.vault_pass` in the
+  configuration repository or export `ANSIBLE_ASK_VAULT_PASS=true` (see the vault
+  note in step 3). Once the manager runs a release whose wrapper supports it,
+  `osism update manager` (`CONTAINER=auto`) does the same thing and can be used
+  instead.
 
 :::
 

--- a/docs/guides/upgrade-guide/manager.mdx
+++ b/docs/guides/upgrade-guide/manager.mdx
@@ -17,6 +17,29 @@ adjustments are necessary. Read the release notes even if you are only updating 
 The update of a manager service with a stable release of OSISM is described here.
 In the example, OSISM release 7.0.5 is used.
 
+:::info Which update path applies to you
+
+Step 3 below drives the `osism.manager.manager` playbook against the manager over
+SSH. The same playbook is used in every case; only how it is launched depends on
+how you deployed the cluster. Steps 1, 2 and 4 to 6 are the same for all of them.
+
+* **Manager with a local Ansible venv** (a self-bootstrapped manager): run
+  `osism update manager` on the manager itself — this is the path described below.
+* **Seed node still available** (a separate workstation or VM that holds the
+  configuration repository, as in the [Seed deploy guide](../deploy-guide/seed.md)):
+  update from the seed instead of the manager. After bumping `manager_version`
+  (step 1) and syncing the configuration repository on the manager (step 2),
+  re-run the manager playbook from the seed:
+
+    ```bash
+    ./run.sh manager
+    ```
+
+  This reuses the same seed tooling as the initial bootstrap, so the manager
+  itself needs no local Ansible installation.
+
+:::
+
 1. Change the OSISM release in the configuration repository.
 
     1. Set the new OSISM version in the configuration repository.

--- a/docs/guides/upgrade-guide/manager.mdx
+++ b/docs/guides/upgrade-guide/manager.mdx
@@ -84,8 +84,13 @@ In the example, OSISM release 7.0.5 is used.
     osism update manager
     ```
 
-    * If Ansible Vault was used to encrypt `environments/manager/secrets.yml`, the parameter
-      `--ask-vault-pass` is also appended. From OSISM >= 8.0.0 this is no longer necessary.
+    * If Ansible Vault was used to encrypt `environments/manager/secrets.yml`, append
+      `--ask-vault-pass` (or set `ANSIBLE_VAULT_PASSWORD_FILE` to the vault password file).
+      Unlike `osism apply`, `osism update manager` runs outside the OSISM workers — it
+      recreates the manager containers and therefore cannot use the worker-side vault
+      password set with `osism set vault password`. The password must be supplied directly
+      whenever `secrets.yml` is encrypted; the OSISM >= 8.0.0 relief from `--ask-vault-pass`
+      applies to `osism apply`, not to this command.
     * If `osism update manager` does not work yet, use `osism-update-manager` instead.
 
 


### PR DESCRIPTION
## What

Give `upgrade-guide/manager.mdx` a seed-container update story. The seed
container is now a documented (and default) deploy path, which can leave a
manager with no local Ansible venv — but the manager update step assumed the
self-bootstrapped manager and gave no guidance otherwise.

## Commits (one concern each)

- `upgrade-guide: fix vault note for manager update` — Corrects the step-3 note:
  the ">= 8.0.0 `--ask-vault-pass` no longer necessary" relief is the `osism apply`
  / worker path. `osism update manager` runs out-of-band (it recreates the manager
  containers) and cannot use the Redis-stored worker vault password, so the
  password must be supplied directly whenever `secrets.yml` is encrypted.
- `upgrade-guide: map manager update to deploy topology` — Adds an admonition
  naming the same `osism.manager.manager` playbook behind every update and
  selecting the launcher by topology: `osism update manager` on a manager with a
  local venv, or re-run `./run.sh manager` from a still-available seed node.
- `upgrade-guide: document seed-container manager update` — Adds the third row: a
  manager deployed with the seed container and separated from its seed (no venv)
  updates with `./run.sh manager` from the configuration repository on the manager
  itself. `run.sh` ships in the repo and is refreshed by `make sync`, so it runs
  the update inside the `osism/seed` container (`SEED_CONTAINER=auto`) independent
  of the manager's installed tooling.

## Merge order

All three commits are accurate on current `main` and can land independently — the
seed-container row uses `run.sh`, which is already released, so the upgrade does
not depend on any unreleased change. Bringing the `osism-update-manager` wrapper
to seed-container parity, so `osism update manager` works as a drop-in alias for
`run.sh`, is a separate and non-blocking improvement:

- osism/ansible-collection-services#2125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
