### PR TITLE
Make formatter errors block CI

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -28,6 +28,9 @@ DISABLE_LINTERS:
 
 SPELL_LYCHEE_DISABLE_ERRORS: true # keep link checks visible without blocking PRs
 
+# Formatter errors are non-blocking by default; make them block CI instead
+FORMATTERS_DISABLE_ERRORS: false
+
 SHOW_ELAPSED_TIME: true
 # Uncomment if you want MegaLinter to detect errors but not block CI to pass
 # DISABLE_ERRORS: true


### PR DESCRIPTION
## What

Set `FORMATTERS_DISABLE_ERRORS: false` in `.mega-linter.yml`.

## Why

MegaLinter's `FORMATTERS_DISABLE_ERRORS` defaults to `true`, which downgrades formatter-type linters (`markdown-table-formatter`, `markdownlint`, `prettier`) to **non-blocking** warnings. As a result PRs merge green even when a formatter reports a genuine error.

This is exactly how the malformed table in `docs/guides/developer-guide/retiring-openstack-releases.md` (added in #994) landed on `main`: `markdown-table-formatter` flagged it on the very first run, but the error was non-blocking, so CI stayed green. It later had to be repaired in an unrelated PR (8ec0356).

Setting the variable to `false` makes formatter errors fail the check, as the MegaLinter docs recommend.

## Heads-up for reviewers

Because the workflow uses `VALIDATE_ALL_CODEBASE: true`, this now blocks on pre-existing formatter debt across the whole repo. The last run still reports ~4 `markdownlint` errors, so CI on this branch is expected to go red until those are also cleaned up. Holding this as a **draft** until we decide whether to clear that debt here or in a precursor PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)