### PR TITLE
betterleaks: allowlist doc example secrets

### DIFF
--- a/.betterleaks.toml
+++ b/.betterleaks.toml
@@ -1,0 +1,20 @@
+# betterleaks (gitleaks fork) configuration for this documentation repository.
+#
+# This is a documentation-only site: values flagged as "secrets" are
+# illustrative example credentials (placeholder keys, demo tokens) shown in
+# guides, not real secrets. We keep the scanner enabled to catch genuine
+# accidental secrets and allowlist the known example values individually.
+#
+# Extend (do not replace) the built-in betterleaks/gitleaks rule set.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Documentation example values (not real secrets)"
+regexes = [
+  # Example Ceph keyring in docs/guides/configuration-guide/ceph/index.mdx
+  '''AQBiHV9nAAAAABAAhtxl8rdW/EBvxiOGw4iMJw==''',
+  # Example noVNC console session token in
+  # docs/guides/user-guide/openstack/migration-vmware-esxi.md
+  '''b9b6920d-e533-4728-8132-a5a0adfc24e5''',
+]


### PR DESCRIPTION
## Problem

MegaLinter's `REPOSITORY_BETTERLEAKS` scanner (a gitleaks fork, pulled via the mutable `@v9` tag) started failing CI by flagging two long-standing **example** values in the docs as leaked secrets:

- the example Ceph keyring in `docs/guides/configuration-guide/ceph/index.mdx`
- the example noVNC console session token in `docs/guides/user-guide/openstack/migration-vmware-esxi.md`

Neither is a real credential. This is a documentation-only site, so illustrative example secrets are expected in the content. The failure is a CI-side regression from the tool upgrade, not a content change — `main` passed on 2026-06-23 and would fail today.

## Change

Add `.betterleaks.toml` that:

- extends the default rule set (`[extend] useDefault = true`) so detection is unchanged, and
- allowlists **only** these two specific values by regex.

MegaLinter auto-detects the config and passes it via `-c`. This keeps betterleaks active to catch a genuinely leaked secret while silencing the known false positives — preferred over disabling the scanner entirely (as is already done for `REPOSITORY_GITLEAKS`).

## Verification

Run with the gitleaks engine bundled in the MegaLinter image:

- the two example values: **2 → 0 findings**
- a real GitHub PAT-format token: **still detected**

🤖 Generated with [Claude Code](https://claude.com/claude-code)