### PR TITLE
image-manager: document preview-by-default

### DIFF
--- a/docs/cloud-in-a-box/index.md
+++ b/docs/cloud-in-a-box/index.md
@@ -287,8 +287,18 @@ can be viewed in the file `/var/log/install-cloud-in-a-box.log`.
 The [OpenStack Image Manager](https://github.com/osism/openstack-image-manager/) is used to manage images.
 In the example, the `Garden Linux` image is imported.
 
+Without `--upload` the command only shows a preview of the images that would be uploaded and
+makes no changes. Add `--upload` to actually import the images.
+
+:::note
+
+Preview by default is available from OSISM `<RELEASE>` onwards. In earlier releases the command
+uploaded the images immediately, without requiring `--upload`.
+
+:::
+
 ```bash
-osism manage images --cloud=admin --filter 'Garden Linux'
+osism manage images --upload --cloud=admin --filter 'Garden Linux'
 ```
 
 All available images can be found in the [osism/openstack-image-manager](https://github.com/osism/openstack-image-manager/tree/main/etc/images) repository.

--- a/docs/guides/operations-guide/openstack/tools/image-manager/index.md
+++ b/docs/guides/operations-guide/openstack/tools/image-manager/index.md
@@ -144,8 +144,26 @@ the help of the OpenStack Image Manager.
 3. Run the OpenStack Image Manager. It is assumed that a profile with the name `openstack` exists in the
    [clouds.yaml](https://docs.openstack.org/python-openstackclient/latest/configuration/index.html#configuration-files).
 
+   By default `openstack-image-manager` (and `osism manage images`, which uses it in the
+   backend) only shows a **preview** of the images that would be uploaded, a rough estimate of
+   how long that would take and the command to actually perform the upload. It does not connect
+   to OpenStack and makes no changes:
+
+   :::note
+
+   Preview by default is available from OSISM `<RELEASE>` onwards. In earlier releases the
+   command uploaded the images immediately, without requiring `--upload`.
+
+   :::
+
    ```bash
    openstack-image-manager --cloud openstack --filter ".*Cirr.*" --images images/
+   ```
+
+   To actually import the images, add `--upload`:
+
+   ```bash
+   openstack-image-manager --upload --cloud openstack --filter ".*Cirr.*" --images images/
    ```
 
 ## Image definitions


### PR DESCRIPTION
## What

Document that the OpenStack Image Manager now previews by default and requires `--upload` to actually import images, following osism/openstack-image-manager#1251.

- **Getting started** guide: explain the preview-by-default behaviour and add an `--upload` variant of the run command.
- **Cloud in a Box** image import example: add `--upload` and a note about the preview behaviour.
- Both docs add a note that preview by default is only available from a certain OSISM release onwards.

## Open items

- [ ] Fill in the `<RELEASE>` placeholder in both files with the concrete OSISM release once the change ships.

## Depends on

This is kept as a **draft** because it depends on osism/openstack-image-manager#1251, which must merge (and be released) first. The `osism manage images` wrapper behaves the same way and also requires `--upload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)