### PR TITLE
thanos_sidecar: remove the network table row

### DIFF
--- a/docs/appendix/networks.md
+++ b/docs/appendix/networks.md
@@ -25,7 +25,6 @@ sidebar_label: Networks
 | `httpd_network`                    | `172.31.101.128/28` |
 | `scaphandre_network`               | `172.31.101.160/28` |
 | `metering_network`                 | `172.31.101.176/28` |
-| `thanos_sidecar_network`           | `172.31.101.192/28` |
 | `gnmic_network`                    | `172.31.101.208/28` |
 | `opentelemetry_collector_network`  | `172.31.101.240/28` |
 | `zuul_network`                     | `172.31.102.0/28`   |


### PR DESCRIPTION
## What

Removes the `thanos_sidecar_network` row from `docs/appendix/networks.md`. The freed `172.31.101.192/28` block is left as a gap (the remaining rows are fixed allocations, not renumbered).

## Why

Retire the thanos_sidecar role/service entirely (osism/issues#1402): its image
`quay.io/thanos/thanos` is frozen at `v0.32.5` (unchanged since 2023-12-18) and its
role-default `# renovate:` annotation is inert (the file is not in the collection's
`renovate.json` fileMatch), so it cannot be maintained — drop it rather than wire it
into release-managed pinning.

## Coordinated set — must land together

Four PRs for osism/issues#1402; deleting the role while its deploy playbook survives
would break the playbook, so they merge as a set:

- osism/ansible-collection-services#2136 — remove the role (+ molecule test + `.zuul.yaml` job)
- osism/ansible-playbooks#565 — remove the deploy playbook
- osism/generics#607 — remove the inventory group
- osism/osism.github.io#1025 — remove the network doc row

## ⚠️ Deploy-behaviour change

thanos_sidecar is **enabled by default** (`enable_thanos_sidecar | default('true')`) and
deploys to the `prometheus` group, so merging this set **stops deploying the Thanos
sidecar on the next run**. Please confirm this is acceptable for existing deployments.
