### PR TITLE
docs: resolve redirecting links and fix broken links

### DIFF
--- a/docs/concepts/components/openstack.md
+++ b/docs/concepts/components/openstack.md
@@ -2,7 +2,7 @@
 
 ## Lifecycle Management of OpenStack in OSISM
 
-The open source project Kolla from the [OpenInfra Foundation](https://openinfra.dev) is
+The open source project Kolla from the [OpenInfra Foundation](https://openinfra.org/) is
 used in OSISM for the life cycle management of OpenStack. Kolla's mission is to provide
 production-ready containers and deployment tools for operating OpenStack clouds. Kolla has
 been actively developed by a very diverse team for 10 years and is one of the most common
@@ -10,7 +10,7 @@ been actively developed by a very diverse team for 10 years and is one of the mo
 
 The container images provided by Kolla are not only used by Kolla itself. They are also used
 in TripleO, the basis for the now discontinued
-[RedHat OpenStack Platform](https://www.redhat.com/en/technologies/linux-platforms/openstack-platform),
+[RedHat OpenStack Platform](https://www.redhat.com/en/technologies/cloud-computing/openstack-services-on-openshift),
 and the [OpenStack Kubernetes Operators](https://github.com/openstack-k8s-operators),
 the basis for the new
 [RedHat OpenStack Services on OpenShift](https://www.redhat.com/en/blog/red-hat-openstack-services-openshift-next-generation-red-hat-openstack-platform).

--- a/docs/concepts/manager.md
+++ b/docs/concepts/manager.md
@@ -82,7 +82,7 @@ The reconciler combines two inventory sources:
 
 * the [configuration repository](../guides/configuration-guide/configuration-repository.md)
   mounted read-only at `/opt/configuration`, and
-* a [NetBox](https://netbox.dev/) instance, if the inventory is generated from NetBox
+* a [NetBox](https://github.com/netbox-community/netbox) instance, if the inventory is generated from NetBox
   data (see [Inventory](../guides/configuration-guide/inventory.md)).
 
 From these sources it renders the effective inventory and writes it to the shared

--- a/docs/concepts/manager.md
+++ b/docs/concepts/manager.md
@@ -26,9 +26,9 @@ the underlying Python API.
 
 ### Job queues (Celery + Redis)
 
-The manager uses [Celery](https://docs.celeryq.dev/) backed by a Redis instance
+The manager uses [Celery](https://docs.celeryq.dev/en/stable/) backed by a Redis instance
 (`manager-redis`) to dispatch and queue Ansible tasks. The same Redis instance also
-serves as the [Ansible facts cache](https://docs.ansible.com/ansible/latest/plugins/cache/redis.html),
+serves as the [Ansible facts cache](https://docs.ansible.com/projects/ansible/latest/plugins/cache/redis.html),
 so that all Ansible containers share the same gathered host facts. Separate
 queues exist for each workload type:
 

--- a/docs/concepts/metalbox.md
+++ b/docs/concepts/metalbox.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 # OSISM MetalBox
 
 The OSISM MetalBox is a hardware-provisioning toolkit built around
-[OpenStack Ironic](https://docs.openstack.org/ironic/). It deploys bare-metal hosts
+[OpenStack Ironic](https://docs.openstack.org/ironic/latest/). It deploys bare-metal hosts
 and bundles every component required to install an OSISM environment offline, so a
 pod can be brought up without external network access. Operators use the MetalBox to
 bootstrap new environments and to manage their lifecycle over time — for example,
@@ -69,13 +69,13 @@ and the configuration volume — see the [OSISM Manager](./manager.md) concept.
 
 ### Ironic
 
-[Ironic](https://docs.openstack.org/ironic/) runs in standalone mode on the
+[Ironic](https://docs.openstack.org/ironic/latest/) runs in standalone mode on the
 MetalBox — that is, without the rest of OpenStack. The only OpenStack service
 deployed alongside it is Keystone for authentication; the supporting infrastructure
 components are MariaDB, Redis, and RabbitMQ.
 
 Servers are provisioned via virtual media: Ironic mounts a small image containing
-the [ironic-python-agent](https://docs.openstack.org/ironic-python-agent/) (IPA)
+the [ironic-python-agent](https://docs.openstack.org/ironic-python-agent/latest/) (IPA)
 over the OOB interface and boots the node from it. During boot, IPA brings up and
 minimally configures the data interfaces of the node, then uses them to talk back
 to Ironic on the MetalBox and to pull the target image, which is written to disk

--- a/docs/guides/configuration-guide/commons/timezone.md
+++ b/docs/guides/configuration-guide/commons/timezone.md
@@ -6,7 +6,7 @@ sidebar_label: Timezone
 
 With the `osism.commons.timezone` role, it is possible to manage the used timezone on a node.
 
-This role is just a wrapper for the [community.general.timezone](https://docs.ansible.com/ansible/latest/collections/community/general/timezone_module.html)
+This role is just a wrapper for the [community.general.timezone](https://docs.ansible.com/projects/ansible/latest/collections/community/general/timezone_module.html)
 module. The role also installs the `tzdata` package.
 
 | Parameter          | Default | Description                                                |

--- a/docs/guides/configuration-guide/configuration-repository.md
+++ b/docs/guides/configuration-guide/configuration-repository.md
@@ -447,15 +447,15 @@ the content available in a configuration repository. In the section
 [Creating a new configuration repository](#creating-a-new-configuration-repository) is the creation
 of a new configuration repository documented.
 
-| Directory/File     | Description                                                                                                                                                                            |
-|:-------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `environments`     |                                                                                                                                                                                        |
-| `inventory`        |                                                                                                                                                                                        |
-| `netbox`           | optional                                                                                                                                                                               |
-| `requirements.txt` | In the `requirements.txt` the necessary dependencies are listed to be able to execute Gilt.                                                                                            |
-| `gilt.yml`         |                                                                                                                                                                                        |
-| `Makefile`         |                                                                                                                                                                                        |
-| `gilt.yaml`        | [Gilt](https://gilt.readthedocs.io) is a Git layering tool. We use Gilt to maintain the image versions, Ansible configuration and scripts within the `environments/manager` directory. |
+| Directory/File     | Description                                                                                                                                                                                       |
+|:-------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `environments`     |                                                                                                                                                                                                   |
+| `inventory`        |                                                                                                                                                                                                   |
+| `netbox`           | optional                                                                                                                                                                                          |
+| `requirements.txt` | In the `requirements.txt` the necessary dependencies are listed to be able to execute Gilt.                                                                                                       |
+| `gilt.yml`         |                                                                                                                                                                                                   |
+| `Makefile`         |                                                                                                                                                                                                   |
+| `gilt.yaml`        | [Gilt](https://gilt.readthedocs.io/en/latest/) is a Git layering tool. We use Gilt to maintain the image versions, Ansible configuration and scripts within the `environments/manager` directory. |
 
 ## Synchronizing the configuration repository
 

--- a/docs/guides/configuration-guide/inventory.md
+++ b/docs/guides/configuration-guide/inventory.md
@@ -7,7 +7,7 @@ sidebar_position: 10
 
 The inventory used for the environment is located in the `inventory` directory.
 
-How an inventory works is described in detail in the [Ansible documentation](https://docs.ansible.com/ansible/latest/inventory_guide/intro_inventory.html).
+How an inventory works is described in detail in the [Ansible documentation](https://docs.ansible.com/projects/ansible/latest/inventory_guide/intro_inventory.html).
 In this chapter, we only deal with special features in the context of OSISM.
 
 ## Manager

--- a/docs/guides/configuration-guide/openstack/cinder.md
+++ b/docs/guides/configuration-guide/openstack/cinder.md
@@ -10,7 +10,7 @@ sidebar_label: Cinder
 
 ## Pure Storage FlashArray
 
-* https://support.purestorage.com/bundle/m_openstack/page/Solutions/topics/concept/c_openstack_02.html
+* https://support.everpuredata.com/r/openstack/openstack-02
 * [Pure Storage OpenStack (2023.2) Cinder Driver Best Practices](https://support-be.purestorage.com/bundle/Pure_Storage_OpenStack_2023.2_Bobcat_Cinder_Driver_Best_Practices/resource/Pure_Storage_OpenStack_2023.2_Bobcat_Cinder_Driver_Best_Practices.pdf)
 * https://github.com/openstack/cinder/blob/master/cinder/volume/drivers/pure.py
 * https://docs.openstack.org/cinder/latest/configuration/block-storage/drivers/everpure-driver.html

--- a/docs/guides/configuration-guide/openstack/index.md
+++ b/docs/guides/configuration-guide/openstack/index.md
@@ -366,8 +366,8 @@ is created and gets into the container.
       },
   ```
 
-* Entrypoint of a service is always [kolla_start](https://github.com/openstack/kolla/blob/master/docker/base/start.sh).
-  This script calls a script [set_configs.py](https://github.com/openstack/kolla/blob/master/docker/base/set_configs.py).
+* Entrypoint of a service is always [kolla_start](https://github.com/openstack/kolla/blob/master/kolla/docker/base/start.sh).
+  This script calls a script [set_configs.py](https://github.com/openstack/kolla/blob/master/kolla/docker/base/set_configs.py).
   This script takes care of copying files from `/var/lib/kolla/config_files` to the right place inside the container.
   For this purpose, the container has a
   [config.json](https://github.com/openstack/kolla-ansible/blob/master/ansible/roles/opensearch/templates/opensearch.json.j2)

--- a/docs/guides/configuration-guide/proxy.md
+++ b/docs/guides/configuration-guide/proxy.md
@@ -34,7 +34,7 @@ As [Gitlab has described in 2021](https://about.gitlab.com/blog/2021/01/27/we-ne
 
 Furthermore, the documentation of certain implementations is not very clear in its statements.
 
-It usually makes sense to exclude all [private ipv4 networks](https://www.rfc-editor.org/rfc/rfc1918) when the involved technology supports this
+It usually makes sense to exclude all [private ipv4 networks](https://www.rfc-editor.org/info/rfc1918/) when the involved technology supports this
 because these private networks or network areas are typically relatively rarely accessed via a proxy anyway but there is a high potential that a network
 which is required to be reached directly is overlooked.
 :::

--- a/docs/guides/configuration-guide/services/docker.md
+++ b/docs/guides/configuration-guide/services/docker.md
@@ -8,7 +8,7 @@ With the `osism.services.docker` role, it is possible to manage Docker.
 
 ## Configure logging drivers
 
-Docker documentation: https://docs.docker.com/config/containers/logging/configure/
+Docker documentation: https://docs.docker.com/engine/logging/configure/
 
 The role currently supports the following parameters with their respective defaults.
 
@@ -21,10 +21,10 @@ docker_log_opts:
 ```
 
 The log driver to be used can be configured with `docker_log_driver`. By default,
-[json-file](https://docs.docker.com/config/containers/logging/json-file/) is used.
+[json-file](https://docs.docker.com/engine/logging/drivers/json-file/) is used.
 The log driver writes all logs of a container to a JSON file
 in `/var/lib/docker/containers`. All supported log drivers can be found in the
-[Docker documentation](https://docs.docker.com/config/containers/logging/configure/#supported-logging-drivers).
+[Docker documentation](https://docs.docker.com/engine/logging/configure/#supported-logging-drivers).
 
 The log level can be configured via `docker_log_level`.
 

--- a/docs/guides/deploy-guide/manager.md
+++ b/docs/guides/deploy-guide/manager.md
@@ -125,7 +125,7 @@ When the `./run.sh operator` is executed, the following prompts are displayed:
   ```
 
 Details on all parameters can be found in
-[Ansible Configuration Settings](https://docs.ansible.com/ansible/latest/reference_appendices/config.html)
+[Ansible Configuration Settings](https://docs.ansible.com/projects/ansible/latest/reference_appendices/config.html)
 in the Ansible documentation.
 
 | Environment variable      | Type    | Description                                                                                                                                                          |

--- a/docs/guides/developer-guide/index.md
+++ b/docs/guides/developer-guide/index.md
@@ -13,9 +13,9 @@ Error cases should be described in such a way that they are directly reproducibl
 the better.
 
 We use GitHub pull requests for contributions. The use of pull requests is documented in the
-official [GitHub documentation](https://docs.github.com/en/github/collaborating-with-pull-requests).
+official [GitHub documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests).
 The process in detail for the creation of a fork, branch etc. is also documented in the
-official [GitHub documentation](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests).
+official [GitHub documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests).
 It is recommended to use the [GitHub CLI](https://cli.github.com). Makes many steps easier.
 
 ## How to add a new service

--- a/docs/guides/developer-guide/style-guide.md
+++ b/docs/guides/developer-guide/style-guide.md
@@ -7,7 +7,7 @@ sidebar_label: Style Guide
 ## Ansible
 
 We implement all the default rules of Ansible Lint. All default rules can be found in the
-[Ansible Lint documentation](https://ansible.readthedocs.io/projects/lint/rules/).
+[Ansible Lint documentation](https://docs.ansible.com/projects/lint/rules/).
 
 ### Task names
 

--- a/docs/guides/developer-guide/zuul.md
+++ b/docs/guides/developer-guide/zuul.md
@@ -353,7 +353,7 @@ The required auth token can be generated on the Zuul control node with the `zuul
 docker exec -it zuul_scheduler zuul-admin create-auth-token --user USER --tenant osism --expires-in 3600 --auth-config zuul_operator
 ```
 
-With the [zuul-client](https://zuul-ci.org/docs/zuul-client/index.html) it is possible to
+With the [zuul-client](https://zuul-ci.org/docs/zuul-client/latest/index.html) it is possible to
 remove the two hanging jobs from the screenshot.
 
 ```bash

--- a/docs/guides/operations-guide/ceph/index.md
+++ b/docs/guides/operations-guide/ceph/index.md
@@ -594,7 +594,7 @@ ceph osd pool delete <pool_name> <pool_name> --yes-i-really-really-mean-it
 In order to be able to delete pools, it has to be enabled on the monitors
 by setting the ``mon_allow_pool_delete`` flag to true. Default is false.
 
-See: https://docs.ceph.com/en/latest/rados/configuration/mon-config-ref
+See: https://docs.ceph.com/en/latest/rados/configuration/mon-config-ref/
 
 :::
 

--- a/docs/guides/operations-guide/infrastructure.md
+++ b/docs/guides/operations-guide/infrastructure.md
@@ -66,7 +66,7 @@ global
 
 ### Backup
 
-[Mariabackup](https://mariadb.com/kb/en/mariabackup-overview/) is used to create backups
+[Mariabackup](https://mariadb.com/docs/server/server-usage/backup-and-restore/mariadb-backup/mariadb-backup-overview) is used to create backups
 of MariaDB. For more details about backups, you can use the official
 [kolla-ansible](https://docs.openstack.org/kolla-ansible/latest/admin/mariadb-backup-and-restore.html) documentation.
 

--- a/docs/guides/operations-guide/manager/console.md
+++ b/docs/guides/operations-guide/manager/console.md
@@ -9,7 +9,7 @@ environment to be operated interactively.
 
 ## Ansible
 
-Used tool: [ansible-console](https://docs.ansible.com/ansible/latest/cli/ansible-console.html)
+Used tool: [ansible-console](https://docs.ansible.com/projects/ansible/latest/cli/ansible-console.html)
 
 ```console
 $ osism console --type ansible testbed-node-0
@@ -25,7 +25,7 @@ Shortcut: `osism console .testbed-node-0`
 
 ## Clush
 
-Used tool: [ClusterShell](https://clustershell.readthedocs.io)
+Used tool: [ClusterShell](https://clustershell.readthedocs.io/en/latest/)
 
 The same groups as defined in the Ansible Inventory can be used.
 
@@ -57,7 +57,7 @@ Shortcut: `osism console testbed-node-0/fluentd`
 
 ## SSH
 
-Used tool: [OpenSSH](https://www.openssh.com)
+Used tool: [OpenSSH](https://www.openssh.org/)
 
 ```console
 $ osism console --type ssh testbed-node-0

--- a/docs/guides/operations-guide/manager/log.md
+++ b/docs/guides/operations-guide/manager/log.md
@@ -195,7 +195,7 @@ AH00558: apache2: Could not reliably determine the server's fully qualified doma
 
 ## OpenSearch
 
-OpenSearch can be queried with [SQL](https://opensearch.org/docs/latest/search-plugins/sql/sql/index/).
+OpenSearch can be queried with [SQL](https://docs.opensearch.org/latest/search-plugins/sql/sql/index/).
 
 ```console
 $ osism log opensearch

--- a/docs/guides/operations-guide/openstack/nova.md
+++ b/docs/guides/operations-guide/openstack/nova.md
@@ -150,7 +150,7 @@ Host aggregates can be managed with the playbook. The playbook is used with
 `osism apply -e openstack host-aggregates`.
 
 Further arguments for host aggregates can be found in the
-[documentation for the openstack.cloud.host_aggregate](https://docs.ansible.com/ansible/latest/collections/openstack/cloud/host_aggregate_module.html) Ansible module.
+[documentation for the openstack.cloud.host_aggregate](https://docs.ansible.com/projects/ansible/latest/collections/openstack/cloud/host_aggregate_module.html) Ansible module.
 
 ```yaml title="environments/openstack/playbook-host-aggregates.yml"
 ---

--- a/docs/guides/operations-guide/openstack/tools/flavor-manager.md
+++ b/docs/guides/operations-guide/openstack/tools/flavor-manager.md
@@ -8,7 +8,7 @@ sidebar_position: 51
 
 The OpenStack Flavor Manager manages the creation, modification, and removal of flavors.
 It operates as a facilitator that orchestrates compute flavors in alignment
-with the standard [SCS-0100: Flavor Naming](https://docs.scs.community/standards/iaas/scs-0100)
+with the standard [SCS-0100: Flavor Naming](https://docs.scs.community/standards/iaas/scs-0100/)
 by utilizing YAML files provided by the SCS project.
 
 ## Installation
@@ -54,7 +54,7 @@ $ openstack-flavor-manager --help
 ╰──────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
-To create the mandatory flavors by the [SCS-0100: Flavor Naming](https://docs.scs.community/standards/iaas/scs-0100)
+To create the mandatory flavors by the [SCS-0100: Flavor Naming](https://docs.scs.community/standards/iaas/scs-0100/)
 standard, you run:
 
 ```bash
@@ -114,7 +114,7 @@ Each definition has its own set of mandatory and recommended flavors. The defini
 all definitions of SCS as well as some others.
 
 To run the OpenStack Flavor Manager with a specific definition, either `scs` or `osism`,
-use the optional `--name` parameter. By default the [SCS-0100: Flavor Naming](https://docs.scs.community/standards/iaas/scs-0100)
+use the optional `--name` parameter. By default the [SCS-0100: Flavor Naming](https://docs.scs.community/standards/iaas/scs-0100/)
 standard definition will be used.
 
 ```bash

--- a/docs/guides/operations-guide/openstack/tools/openstack-health-monitor.md
+++ b/docs/guides/operations-guide/openstack/tools/openstack-health-monitor.md
@@ -15,7 +15,7 @@ Note: This is a rather classical snowflake setup -- we create a VM and do some m
 openstack-health-monitor implements a scripted scenario test with a large shell-script that uses the openstackclient tools to set up the scenario, test it and tear everything down again in a loop. Any errors are recorded, as well as timings and some very basic benchmarks. The script sets up some virtual network infrastructure (routers, networks, subnets, floating IPs), security groups, keypairs, volumes and finally boots some VMs. Access to these is tested (ensuring metadata injection works) and connectivity between them tested and measured. A loadbalancer (optionally) is set up with a health-monitor and access via it before and after killing some backends is tested.
 The scenario is described in a bit more detail in the [repository's README.md](https://github.com/SovereignCloudStack/openstack-health-monitor/blob/main/README.md) file.
 
-The openstack-health-monitor is not the intended long-term solution for monitoring your infrastructure. The SCS project has a project underway that will create more modern, flexible, and more maintainable monitoring infrastructure; the concepts are described on the [monitoring section](https://docs.scs.community/docs/category/monitoring) of the project's documentation. The openstack-health-monitor will thus not see any significant enhancements any more; it will be maintained and kept alive as long as there are users. This guide exclusively focuses on how to set it up.
+The openstack-health-monitor is not the intended long-term solution for monitoring your infrastructure. The SCS project has a project underway that will create more modern, flexible, and more maintainable monitoring infrastructure; the concepts are described on the [monitoring section](https://docs.scs.community/docs/category/monitoring/) of the project's documentation. The openstack-health-monitor will thus not see any significant enhancements any more; it will be maintained and kept alive as long as there are users. This guide exclusively focuses on how to set it up.
 
 ## Setting up the driver VM
 
@@ -82,7 +82,7 @@ Sidenote: The `tr` command is there to handle broken tooling that embeds a trail
 ```bash
 openstack server create --network oshm-network --key-name oshm-key --security-group default --security-group sshping --security-group grafana --flavor SCS-2V-4 --block-device boot_index=0,uuid=$IMGUUID,source_type=image,volume_size=10,destination_type=volume,delete_on_termination=true oshm-driver
 ```
-Chose a flavor that exists on your cloud. Here we have used  one without root disk and asked nova to create a volume on the fly by passing `--block-device`. See [diskless flavor blog article](https://scs.community/2023/08/21/diskless-flavors/). For flavors with local root disks, you could have used the `--image $IMGUUID` parameter instead.
+Chose a flavor that exists on your cloud. Here we have used  one without root disk and asked nova to create a volume on the fly by passing `--block-device`. See [diskless flavor blog article](https://sovereigncloudstack.org/en/community_blog/preferring-diskless-flavours-in-scs/). For flavors with local root disks, you could have used the `--image $IMGUUID` parameter instead.
 
 7. Wait for it to boot (optional)
 You can look at the boot log with `openstack console log show oshm-driver` or connect to it via VNC at the URL given by `openstack console url show oshm-driver`. You can of course also query openstack on the status `openstack server list` or `openstack server show oshm-driver`. You can also just create a simple loop:
@@ -607,7 +607,7 @@ Please replace `YOUR_CLIENT_ID` and `YOUR_CLIENT_SECRET` with the OAuth2 credent
 provided to you.
 Finally, don't forgot to restart Grafana with `sudo systemctl restart grafana-server` after adjusting the config.
 
-More information can be found in the [Grafana documentation for GitHub OAuth2](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/github/).
+More information can be found in the [Grafana documentation for GitHub OAuth2](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/github/).
 
 ## Maintenance
 
@@ -615,7 +615,7 @@ The driver VM is a snowflake: A manually set up system (unless you automate all 
 
 ### Unattended upgrades
 
-It is recommended to ensure maintenance updates are deployed automatically. These are unlikely to negatively impact the openstack-health-monitor. See https://wiki.debian.org/UnattendedUpgrades. If you decide against unattended upgrades, it is recommended to install updates manually regularly and especially watch out for issues that affect the services that are exposed to the world: sshd (port 22) and Caddy/Grafana (port 3000).
+It is recommended to ensure maintenance updates are deployed automatically. These are unlikely to negatively impact the openstack-health-monitor. See https://wiki.debian.org/PeriodicUpdates?action=show&redirect=UnattendedUpgrades. If you decide against unattended upgrades, it is recommended to install updates manually regularly and especially watch out for issues that affect the services that are exposed to the world: sshd (port 22) and Caddy/Grafana (port 3000).
 
 If you use `unattended-upgrades`, you should review your settings in `/etc/apt/apt.conf.d/50unattended-upgrades`,
 especially `Unattended-Upgrade::Origins-Pattern`. It controls which packages are upgraded. If you want Caddy to be

--- a/docs/guides/upgrade-guide/docker.md
+++ b/docs/guides/upgrade-guide/docker.md
@@ -86,7 +86,7 @@ running containers. This can lead to interruptions in individual services. A cha
 required restart.
 
 Whether the containers are restarted when the Docker Service is restarted depends on whether the
-[Live Restore feature](https://docs.docker.com/config/containers/live-restore/) is used.
+[Live Restore feature](https://docs.docker.com/engine/daemon/live-restore/) is used.
 This can be configured via the parameter `docker_live_restore`. Live restore is enabled by default.
 
 It is important to set the `docker_live_restore` parameter explicitly as a string. This means

--- a/docs/guides/user-guide/openstack/migration-vmware-esxi.md
+++ b/docs/guides/user-guide/openstack/migration-vmware-esxi.md
@@ -17,7 +17,7 @@ providers that perform migration from VMware ESXi to OpenStack. One of the offer
 
 A good overview and comparison of VMWare resources and their OpenStack
 counterparts is available
-[in the OpenStack documentation](https://www.openstack.org/vmware-migration-to-openstack).
+[in the OpenStack documentation](https://www.openstack.org/vmware-migration-to-openstack/).
 
 
 ## Scenario

--- a/docs/guides/user-guide/openstack/openstackclient.md
+++ b/docs/guides/user-guide/openstack/openstackclient.md
@@ -134,7 +134,7 @@ clouds = {
 print(yaml.dump(clouds))
 ```
 
-Source: [Adam Young's Web Log](https://adam.younglogic.com/2022/03/generating-a-clouds-yaml-file)
+Source: [Adam Young's Web Log](https://adam.younglogic.com/2022/03/generating-a-clouds-yaml-file/)
 
 First you need to source your `openrc` file so that the `OS_` variables are available.
 
@@ -175,4 +175,4 @@ clouds:
     identity_api_version: $OS_IDENTITY_API_VERSION
 EOF
 ```
-Source: [Andreas Karis Blog](https://andreaskaris.github.io/blog/openstack/using_clouds_yaml)
+Source: [Andreas Karis Blog](https://andreaskaris.github.io/blog/openstack/using_clouds_yaml/)

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -5,13 +5,6 @@ sidebar_position: 95
 
 # Release Notes
 
-:::info
-
-The old release notes (before OSISM 7) can be found on the archived page
-[release.osism.tech](https://release.osism.tech).
-
-:::
-
 | Series                    | Status               | Initial Release Date | Next Phase           |
 |:--------------------------|:---------------------|:---------------------|:---------------------|
 | [OSISM 10](./osism-10.md) | Maintained           | 20. March 2026       | Extended Maintenance |

--- a/docs/release-notes/osism-7.md
+++ b/docs/release-notes/osism-7.md
@@ -37,7 +37,7 @@ Release date: 8. September 2024
     issues. Further details can be found in security advisory
     [OSSA-2024-003: Unvalidated image data passed to qemu-img](https://security.openstack.org/ossa/OSSA-2024-003.html)
     and in SCS blog post
-    [Sovereign Cloud Stack Security Advisory Image Processing in Ironic (CVE-2024-44082)](https://scs.community/de/security/2024/09/07/cve-2024-44082/). This upgrade is important.
+    [Sovereign Cloud Stack Security Advisory Image Processing in Ironic (CVE-2024-44082)](https://sovereigncloudstack.org/community_blog/sovereign-cloud-stack-security-advisory-image-processing-in-ironic-cve-2024-44082/). This upgrade is important.
 
 * New manager features.
 
@@ -131,7 +131,7 @@ Release date: 12. August 2024
     issues. Further details can be found in security advisory
     [OSSA-2024-002: Incomplete file access fix and regression for QCOW2 backing files and VMDK flat descriptors](https://security.openstack.org/ossa/OSSA-2024-002.html)
     and in SCS blog post
-    [SCS Security Advisory on incomplete QCOW2 and VMDK image handling protections (CVE-2024-40767)](https://scs.community/de/security/2024/07/23/cve-2024-40767/). This upgrade is important. If a hotfix for this problem has already
+    [SCS Security Advisory on incomplete QCOW2 and VMDK image handling protections (CVE-2024-40767)](https://sovereigncloudstack.org/community_blog/scs-security-advisory-on-incomplete-qcow2-and-vmdk-image-handling-protections-cve-2024-40767/). This upgrade is important. If a hotfix for this problem has already
     been deployed in advance, the parameters added for this in `environments/kolla/images.yml`
     must be removed again.
 
@@ -196,7 +196,7 @@ Release date: 10. July 2024
     issues. Further details can be found in security advisory
     [OSSA-2024-001: Arbitrary file access through custom QCOW2 external data](https://security.openstack.org/ossa/OSSA-2024-001.html)
     and in SCS blog post
-    [SCS Security Advisory on arbitrary file access through QCOW2 external data file (CVE-2024-32498)](https://scs.community/de/security/2024/07/02/cve-2024-32498/). This upgrade is important. If a hotfix for this problem has already
+    [SCS Security Advisory on arbitrary file access through QCOW2 external data file (CVE-2024-32498)](https://sovereigncloudstack.org/community_blog/scs-security-advisory-on-arbitrary-file-access-through-qcow2-external-data-file-cve-2024-32498/). This upgrade is important. If a hotfix for this problem has already
     been deployed in advance, the parameters added for this in `environments/kolla/images.yml`
     must be removed again.
 
@@ -398,7 +398,7 @@ Release date: 24. May 2024
 * New documentation.
 
   * The documentation for the
-    [initial creation of a configuration repository using Cookiecutter](https://osism.tech/docs/guides/configuration-guide/configuration-repository)
+    [initial creation of a configuration repository using Cookiecutter](https://osism.tech/docs/guides/configuration-guide/configuration-repository/)
     has been completely revised. In the Cookiecutter itself, notes have been added in many places to simplify
     the initial reworking of the created configuration repository.
 
@@ -477,8 +477,8 @@ the resulting effort.
   to perform significantly more tests than with the previously used `osism.validations.refstack` role. The new
   role will be used in the testbed in future to significantly increase the number of tests performed in the CI.
 
-* New documentation for the [project manager](https://osism.tech/docs/guides/operations-guide/openstack/tools/project-manager)
-  and the [simple stress](https://osism.tech/docs/guides/operations-guide/openstack/tools/simple-stress).
+* New documentation for the [project manager](https://osism.tech/docs/guides/operations-guide/openstack/tools/project-manager/)
+  and the [simple stress](https://osism.tech/docs/guides/operations-guide/openstack/tools/simple-stress/).
 
 * When using the reboot play, it is now possible to wait for the reboot to be completed ([osism/issues#758](https://github.com/osism/issues/issues/758)).
 

--- a/docs/testbed/appendix.mdx
+++ b/docs/testbed/appendix.mdx
@@ -77,7 +77,7 @@ The defaults for the OpenTofu variables are intended for [REGIO.cloud](https://r
 
 The following stable Ceph and OpenStack releases are supported.
 
-The deployment of Ceph is based on [ceph-ansible](https://docs.ceph.com/ceph-ansible/).
+The deployment of Ceph is based on [ceph-ansible](https://docs.ceph.com/projects/ceph-ansible/en/latest/).
 
 * Ceph Quincy (**default**)
 * Ceph Reef
@@ -89,7 +89,7 @@ The deployment of OpenStack is based on [kolla-ansible](https://docs.openstack.o
 * OpenStack 2024.2 (**default**)
 * OpenStack 2025.1
 
-The deployment of Kubernetes is based on [k3s-ansible](https://github.com/techno-tim/k3s-ansible).
+The deployment of Kubernetes is based on [k3s-ansible](https://github.com/timothystewart6/k3s-ansible).
 
 * Kubernetes v1.32 (**default**)
 

--- a/docs/testbed/index.md
+++ b/docs/testbed/index.md
@@ -20,7 +20,7 @@ With the OSISM Testbed, it is possible to run a full Sovereign Cloud Stack
 deployment on an existing OpenStack environment such as Cleura or [REGIO.cloud](https://regio.digital).
 
 OSISM is the reference implementation for the Infrastructure as a Service (IaaS) layer in the
-[Sovereign Cloud Stack](https://www.sovereigncloudstack.org) (SCS) project. The OSISM Testbed is therefore
+[Sovereign Cloud Stack](https://sovereigncloudstack.org/) (SCS) project. The OSISM Testbed is therefore
 used in the SCS project to test and work on the Infrastructure as a Service layer.
 
 To get started with Testbed we first need to [prepare our environment](prerequisites.mdx).

--- a/docs/testbed/prerequisites.mdx
+++ b/docs/testbed/prerequisites.mdx
@@ -67,7 +67,7 @@ The OSISM Testbed requires at least the following project quota when using the d
 ## Software
 
 * `make` must be installed on the system
-* [Wireguard](https://wireguard.com) or [`sshuttle`](https://github.com/sshuttle/sshuttle) must be installed on your system for VPN access
+* [Wireguard](https://www.wireguard.com/) or [`sshuttle`](https://github.com/sshuttle/sshuttle) must be installed on your system for VPN access
 * Python must be installed, the Python version used must be at least 3.10, otherwise
   the current Ansible release cannot be used (more details in the
   [Ansible support matrix](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix))


### PR DESCRIPTION
## Summary

The MegaLinter lychee link check [reported 49 links](https://github.com/osism/osism.github.io/actions/runs/29446201398/job/87457169698) in the documentation that resolve via HTTP redirects, hinting they should be replaced with their resolved targets. This pins each link to its current destination so builds stop following redirects and don't rely on intermediate URLs that can silently rot. While in the documentation, a few unrelated broken links were also fixed.

## Changes

### Redirect cleanup (commit 1)

Replacements fall into three groups:

- **Trailing-slash normalizations** where the server 301s to add a slash (`osism.tech` guides, `docs.openstack.org/ironic`, `rfc-editor.org`, …).
- **Path moves within the same site** (`docs.ansible.com/ansible/latest` → `/projects/ansible/latest`, `docs.docker.com/config/containers` → `/engine`, the GitHub pull-request docs, the Grafana auth docs).
- **Domain moves** (`www.sovereigncloudstack.org` → `sovereigncloudstack.org`, `openinfra.dev` → `openinfra.org`, `www.openssh.com` → `.org`, `support.purestorage.com` → `support.everpuredata.com`, the `scs.community` blog and security posts → `sovereigncloudstack.org`).

### NetBox link (commit 2)

`https://netbox.dev/` resolved through four hops to the vendor page `netboxlabs.com/products/netbox/`. Rather than point the docs at a product/marketing page, this replaces it with the community source repository `https://github.com/netbox-community/netbox`, which is the canonical open-source project and resolves without redirects.

### Kolla source links (commit 3)

Two links to the Kolla container entrypoint scripts (`start.sh`, `set_configs.py`) returned 404. Upstream Kolla moved its sources under a top-level `kolla/` package directory, so `docker/base/…` is now `kolla/docker/base/…`. Both links are updated to the current paths.

### Dead archived release-notes link (commit 4)

The release-notes overview linked to `https://release.osism.tech` for pre-OSISM-7 notes. That subdomain no longer resolves (NXDOMAIN) and the archived site is gone, so the info admonition is removed.

## Intentionally left unchanged

- `https://github.com/osism/issues/issues/new` returns a **302 to a GitHub login page** (`return_to=…`) — an authentication redirect, not a content move. Following it would break the "open an issue" link.

## Verification

Re-running lychee locally (v0.24.2, same as CI) confirms the documentation no longer contains resolvable redirects apart from the intentionally-kept GitHub login redirect above, and no broken links, with no new issues introduced. The one markdown table affected by a lengthened URL (`configuration-guide/configuration-repository.md`) was reformatted with `markdown-table-formatter` to keep column alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)