### PR TITLE
concepts: add release cadence documentation

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -51,6 +51,13 @@ MetalBox's components.
 * Logging, Monitoring & Telemetry with [Prometheus](https://prometheus.io/) & [Grafana](https://grafana.com/)
 * [Realtime insights with Netdata](./components/netdata.md)
 
+## Release Cadence
+
+OSISM cuts one major release per year, anchored on the spring SLURP (`YYYY.1`)
+OpenStack release, and supports the current release plus the one before it. The
+[Release Cadence](./release-cadence.md) chapter explains the release timing, which
+OpenStack releases OSISM ships, and how long each release is maintained.
+
 ## Technology Adaptability
 
 OSISM integrates proven open source projects into a cohesive cloud platform. As

--- a/docs/concepts/release-cadence.md
+++ b/docs/concepts/release-cadence.md
@@ -1,0 +1,173 @@
+---
+sidebar_label: Release Cadence
+sidebar_position: 10
+---
+
+# Release Cadence
+
+This chapter describes how often OSISM produces a major release, which upstream
+releases each major release is built on, and how long a release is supported.
+The model described here is derived from how OSISM environments are actually
+operated in practice — most notably the time operators need to plan and carry
+out an upgrade — rather than from a fixed calendar.
+
+## Why the cadence follows OpenStack and Kolla
+
+The two most important components of an OSISM cloud pod are OpenStack and the
+[Kolla](https://docs.openstack.org/kolla/latest/) images that OSISM uses to
+deploy it. Everything else in a release — Ceph, the networking stack, the
+Kubernetes layers, identity, monitoring — is integrated and tested around that
+OpenStack version. It therefore makes sense to anchor the OSISM release cadence
+to the upstream OpenStack and Kolla release cycles instead of defining an
+independent schedule.
+
+## Upstream release cycle
+
+OpenStack follows a fixed six-month cycle and produces two releases per year:
+
+* a `YYYY.1` release in **April** (for example `2026.1` Gazpacho),
+* a `YYYY.2` release in **October** (for example `2025.2` Flamingo).
+
+The `YYYY.1` (April) releases are **SLURP** releases (Skip-Level Upgrade Release
+Process). SLURP releases are maintained upstream for longer than the non-SLURP
+releases in between them and allow operators to upgrade once per year while
+skipping the intermediate `YYYY.2` release. OpenStack does not use a formal
+"LTS" label; the SLURP release is the closest equivalent and is what OSISM
+treats as the long-term-support anchor.
+
+:::info
+
+**OSISM only ships and officially supports SLURP (`YYYY.1`) OpenStack releases.**
+The non-SLURP `YYYY.2` releases are intentionally skipped so that every OSISM
+major release lands on a version with the longer upstream maintenance window and
+a supported skip-level upgrade path.
+
+We do build the intermediate `YYYY.2` Kolla images for evaluation and testing
+purposes, but they come with **no officially supported upgrade path and no
+security updates**. They are not intended for production use.
+
+:::
+
+Each OSISM major version therefore maps one-to-one to the spring SLURP release
+of its year:
+
+| OSISM | OpenStack (SLURP, `YYYY.1`) | Name     |
+|:------|:----------------------------|:---------|
+| 10    | 2025.1                      | Epoxy    |
+| 11    | 2026.1                      | Gazpacho |
+| 12    | 2027.1                      | Indri    |
+| 13    | 2028.1                      | (TBA)    |
+
+Kolla follows the OpenStack
+[cycle-trailing](https://docs.openstack.org/kolla/latest/contributor/release-management.html)
+release model: it is released **up to about three months after** the
+corresponding OpenStack coordinated release, giving it time to wait for
+distribution packages and stabilise against the new OpenStack version.
+
+## When OSISM releases
+
+OSISM cuts one major release per year, timed **about one month after the Kolla
+release** for the anchoring SLURP OpenStack version. Chained together, the
+upstream milestones lead to an OSISM major release around **August**:
+
+| Milestone                                      | Approximate timing | Example (2026 cycle)             |
+|:-----------------------------------------------|:-------------------|:---------------------------------|
+| OpenStack SLURP release (`YYYY.1`)             | April              | `2026.1` Gazpacho — 1 April 2026 |
+| Kolla release (cycle-trailing, ~3 months)      | ~July              | ~July 2026                       |
+| **OSISM major release** (~1 month after Kolla) | **~August**        | ~August 2026                     |
+
+The exact date shifts with the actual upstream releases — if Kolla slips, the
+OSISM release moves with it — but the ordering and the roughly one-per-year
+cadence stay the same.
+
+:::info
+
+Similar to the Ubuntu point release model, the first release of a new OSISM
+major version is intended for new installations, early adopters, and testing.
+For existing production environments we recommend waiting for the first point
+release before upgrading.
+
+The first point release is shipped **at the latest two months after the initial
+major release**. This gives early adopters enough time to complete their
+upgrades and surface any issues, while still keeping the upgrade window for
+production environments predictable.
+
+:::
+
+## What the release cadence covers
+
+The OSISM release cadence is about the **OSISM framework** and the **OpenStack
+release it officially supports** — not about the exact container images shipped
+at any given moment.
+
+Each OSISM major release is built and integration-tested around **one SLURP
+OpenStack release**, deployed through the Kolla images that OSISM builds. The
+OpenStack version is tied to the OSISM major release: upgrading the framework is
+meant to go hand in hand with upgrading the OpenStack deployment it manages.
+The framework can run against an older OpenStack version — this is required so
+that an upgrade has a valid intermediate state — but that is a transitional
+situation during an upgrade, not a configuration meant to be kept permanently.
+
+Not every component is bound to this cadence. Kubernetes is managed with
+[Gardener](./components/gardener.md) and Ceph with cephadm, and both are updated
+independently of the OSISM major release. Ceph in particular is only the storage
+backend and has no hard dependency on the OpenStack version, so it follows its
+own upstream support timeline rather than the OSISM framework cadence.
+
+Major releases are therefore where the **OpenStack upgrade**, **deprecations and
+removals**, and **new features are introduced or configuration changes** happen.
+Within a major release, OSISM ships **minor releases** as needed — roughly every
+six to eight weeks — for framework updates and bug fixes. You can move from any
+minor version to a higher one within the same major release without special
+intervention. For the mechanics of how releases are produced, see
+[Releases](../guides/developer-guide/releases.md) in the developer guide.
+
+### Security fixes
+
+Security fixes for OpenStack and the other Kolla-based components are shipped as
+part of the **Kolla container images** that OSISM builds, independently of the
+OSISM framework release cadence. Because OSISM maintains rolling image tags for
+every major release, security-fixed images can be deployed without changing the
+OSISM release itself — security updates are not gated on the six-to-eight-week
+minor release cadence.
+
+## Support and lifecycle
+
+OSISM supports **the current major release plus the one before it**. As soon as
+a new major release ships, the previous release enters a deprecation window that
+gives operators time to upgrade before it reaches end of life.
+
+The length of that window is set by observed operator behaviour: operators
+report that they need roughly **six to nine months** to plan and complete an
+upgrade after a new OSISM release becomes available. The deprecation window is
+sized to cover that need.
+
+A major release therefore moves through three phases:
+
+| Phase                    | Duration                                               | What operators receive                                                                                                                                   |
+|:-------------------------|:-------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Maintained**           | From release until the next major release (~12 months) | Full updates: minor releases, bug fixes, security fixes, and any mandatory feature or config changes.                                                    |
+| **Extended Maintenance** | 6–9 months after the next major release ships          | Critical and security fixes only. This is the upgrade window — operators should move to a newer release.                                                 |
+| **End of Life**          | —                                                      | No further updates. See [Retiring OpenStack Releases](../guides/developer-guide/retiring-openstack-releases.md) for how bundled versions are wound down. |
+
+This gives each major release an effective supported lifetime of roughly
+**18 to 21 months** (about 12 months Maintained plus the 6–9 month Extended
+Maintenance window). At any given time exactly two releases are supported: the
+newest one (Maintained) and the one before it (Extended Maintenance).
+
+### Example timeline
+
+Assuming a major release *N* ships in August:
+
+* **August, year Y** — release *N* ships and enters **Maintained**. The
+  previous release *N-1* moves from Maintained to **Extended Maintenance**, and
+  the release before that, *N-2*, reaches **End of Life**.
+* **August, year Y+1** — release *N+1* ships. *N* moves to Extended
+  Maintenance; *N-1* reaches End of Life once its 6–9 month window has elapsed.
+
+An operator running *N-1* when *N* ships thus has the full Extended Maintenance
+window — six to nine months — to complete their upgrade before their release
+reaches end of life.
+
+For the current status and dates of each release, see the
+[Release Notes](../release-notes/index.md).

--- a/docs/guides/developer-guide/releases.md
+++ b/docs/guides/developer-guide/releases.md
@@ -33,270 +33,96 @@ removed.
 
 ## How to make a release
 
-1. On all repositories that are used, check that the versions to be used have an
-   appropriate version tag (e.g. `v0.20230308.0`).
+All component versions of a release are pinned in the
+[osism/release](https://github.com/osism/release) repository. The mechanics
+inside that repository — continuous version updates via Renovate, tagging the
+core container image projects with `scripts/create-tags.sh`, freezing a
+release with `src/create-version.py`, and changelog generation — are
+documented in the
+[README of the osism/release repository](https://github.com/osism/release#release-process).
 
-   ```text
-   osism/ansible-collection-commons
-   osism/ansible-collection-services
-   osism/ansible-collection-validations
-   osism/ansible-defaults
-   osism/ansible-playbooks
-   osism/ansible-playbooks-manager
-   osism/cf-generics
-   osism/kolla-operations
-   osism/python-osism
-   ```
+The checklist below covers the overall release flow, including the steps that
+happen outside the osism/release repository.
 
-2. Copy the `latest` directory. The release to be created is used as the new name.
+:::note Major releases: sync the inventory first
 
-   ```text
-   latest -> 6.0.0b
-   ```
+If the release moves to a new OpenStack series, bump `KOLLA_BRANCH` in
+[osism/generics](https://github.com/osism/generics)
+`src/check-kolla-inventory.py` to the matching `stable/<series>` branch and
+resolve the drift the `generics-tox-check-kolla` job then reports — add the
+new kolla-ansible service groups to the inventory (or, for services OSISM does
+not deploy, to the IGNORE lists) and merge. The inventory is baked into the
+`osism-ansible` and `inventory-reconciler` images, so it must match the new
+series before the release candidate is built and tested; otherwise the testing
+in the steps below validates an inventory that aborts on the new release.
 
-3. Remove all `# renovate` lines from the `base.yml` file.
+:::
 
-4. Remove all Ceph and OpenStack releases that should not be part of the pre-release.
-   There is only one OpenStack version and one Ceph version per (pre-)release.
+1. Create one or more release candidates (e.g. `10.1.0-rc.1`) in the
+   osism/release repository as described in its README.
 
-5. Ensure that the symlinks `openstack.yml` and `ceph.yml` point to the releases
-   to be used in this pre-release.
+2. Add temporary release candidate jobs to `.zuul.yaml` in the
+   [osism/testbed](https://github.com/osism/testbed) repository that deploy
+   the release candidate and upgrade from the current stable release to the
+   release candidate (e.g. `abstract-testbed-deploy-rc` with
+   `manager_version: 10.1.0-rc.1` and `abstract-testbed-upgrade-rc`).
 
-   ```text
-   base.yml
-   ceph-pacific.yml
-   ceph.yml -> ceph-pacific.yml
-   openstack-zed.yml
-   openstack.yml -> openstack-zed.yml
-   ```
+3. Test. Test. Test.
 
-6. Run `src/prepare-release.py`.
+4. Create the final release version (e.g. `10.1.0`) in the osism/release
+   repository as described in its README.
 
-   ```bash
-   RELEASE=6.0.0b python3 src/prepare-release.py
-   ```
+5. Switch the pinned stable jobs in the
+   [osism/testbed](https://github.com/osism/testbed) repository to the new
+   release and remove the temporary release candidate jobs added in step 2.
+   Do this before the documentation steps that follow: the stable jobs are
+   what validate the release, so they must pass before it is announced. For
+   the `10.1.0` example the version variables change as follows.
 
-7. Do the steps from the `Stable release` starting from the 4th step.
+   - Deploy jobs (`abstract-testbed-deploy-stable` and
+     `abstract-testbed-deploy-stable-in-a-nutshell`): set `manager_version`
+     to the new release — `10.1.0`.
 
-### Stable release
+   - Upgrade job (`testbed-upgrade-stable-*`): a major upgrade across the
+     series boundary, from the last release of the previous major series to
+     the new release — `manager_version: 9.5.0`,
+     `manager_version_next: 10.1.0`.
 
-1. Copy the directory of the last pre-release or the previous stable release.
-   The release to be created is used as the new name.
+   - Update job (`testbed-update-stable-*`): a minor update within the same
+     major series, from the preceding release in the series to the new
+     release — `manager_version: 10.0.0`, `manager_version_next: 10.1.0`.
+     The first release of a new major series has no in-series predecessor,
+     so this job only becomes meaningful from the second release of a series
+     onwards.
 
-   ```text
-   5.0.0a -> 5.0.0b
-   5.0.0b -> 5.0.0
-   5.0.0  -> 5.1.0
-   5.1.0  -> 5.2.0
-   5.2.0  -> 5.3.0
-   ```
+   The jobs that track the development head instead of a pinned release —
+   `testbed-update-stable-current-*` (update to `latest`) and
+   `testbed-upgrade-stable-next-*` (upgrade to `latest`) — are not touched
+   here. All stable jobs must pass successfully.
 
-2. Change all necessary versions in the YAML files within the new directory.
-   In any case, the version of the pre-release or the version of the stable
-   release must be replaced by the release to be created.
+6. Add release notes to the
+   [osism/osism.github.io](https://github.com/osism/osism.github.io)
+   repository: a new `docs/release-notes/osism-N.md` file for a major
+   release, or a new entry in the existing file for a minor release.
 
-3. The release to be created is submitted as a pull request as usual and then
-   merged.
+7. Update the version examples in the documentation that reference a concrete
+   release, e.g. `docs/guides/configuration-guide/manager.mdx`,
+   `docs/guides/upgrade-guide/manager.mdx` and
+   `docs/guides/configuration-guide/configuration-repository.md`.
 
-4. Add a tag with the name of the new release to the listed repositories.
-
-   ```text
-   osism/container-image-ceph-ansible
-   osism/container-image-inventory-reconciler
-   osism/container-image-osism-ansible
-   osism/container-images-kolla
-   ```
-
-5. After completing the creation of the images in repository `container-images-kolla`,
-   the file `images.yml` must be added to repository `osism/sbom` as
-   `5.0.0/openstack.yml` (instead of `5.0.0`, the corresponding release is used).
-   The file is available as a build artifact of the `Release container images` action
-   on the created tag.
-
-   Before the file is added, it is enhanced with the checksums of the images. The script
-   is available in the `osism/sbom` repository.
-
-   ```bash
-   VERSION=5.0.0 python3 scripts/add-image-checksum.py
-   ```
-
-6. If `5.0.0/openstack.yml` is present in `osism/sbom`, repository
-   `osism/container-image-kolla-ansible` can be tagged like the other
-   repositories before.
-
-7. Add the created SPDX files from the listed repositories to the `osism/sbom` repository.
-   The file are available as build artifacts of the ``Build container image`` action
-   on the created tags.
-
-   ```text
-   osism/container-image-ceph-ansible
-   osism/container-image-kolla-ansible
-   osism/container-image-osism-ansible
-   ```
-
-8. Add and run temporary CI jobs in `osism/testbed` that uses the pre-release.
-
-   ```yaml
-   - job:
-       name: testbed-deploy-stable-next
-       parent: testbed-deploy
-       vars:
-         manager_version: "5.0.0a"
-         refstack: true
-       nodeset: testbed-orchestrator
-
-   - job:
-       name: testbed-upgrade-stable-next
-       parent: testbed-deploy
-       vars:
-         manager_version: "4.2.0"
-         manager_version_next: "5.0.0a"
-       nodeset: testbed-orchestrator
-   ```
-
-9. Test. Test. Test.
-
-10. Prepare a PR to change the stable version to the new stable version in the following Zuul jobs
-    in the `osism/testbed` repository. All tests there must pass successfully before the tag is
-    set on this repository in the next step. The temporary CI jobs (step 8)  are removed again with
-    this PR.
-
-    ```text
-    testbed-deploy-stable
-    testbed-update-stable
-    testbed-update-stable
-    testbed-upgrade-stable
-    ```
-
-11. Add a new release notes file to `doc/source/notes`. Generate the versions table with the
-    help of the `release-table.py` script in the `osism/sbom` repository.
-
-12. After all known issues are documented, a corresponding tag, e.g. `5.0.0`, is set on the
-    [osism/release](https://github.com/osism/release/releases) repository.
-
-13. Create a [GitHub release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) with the new tag on the
-    [osism/release](https://github.com/osism/release/releases) repository. The release is
-    now public available.
-
-14. As the last of the release process, the previously prepared PR is merged on the
-    `osism/testbed` repository to change the stable version.
+8. As the last step, bump the `manager_version` default in the
+   [osism/cfg-cookiecutter](https://github.com/osism/cfg-cookiecutter)
+   repository so that newly created configuration repositories use the new
+   release. The documentation promises that this default is always the latest
+   stable release.
 
 ## How we write release notes
 
-We use [Reno](https://docs.openstack.org/reno/latest/) to manage the release notes.
+Release notes for OSISM releases are maintained as Markdown pages in the
+[osism/osism.github.io](https://github.com/osism/osism.github.io) repository
+(`docs/release-notes/`) and published at
+[osism.tech/docs/release-notes](https://osism.tech/docs/release-notes/).
 
-### Installation
-
-Reno is provided as a [Python package](https://pypi.org/project/reno/) and can be installed with pip.
-
-```bash
-pip3 install reno
-```
-
-### Usage
-
-For each change in a repository, a release note is created with Reno.
-Something meaningful is used as the name for the note. For example, if the
-requirements file for Ansible is removed, `remove-ansible-requirements` is a good name.
-
-```console
-$ reno new remove-ansible-requirements
-no configuration file in: ./releasenotes/config.yaml, ./reno.yaml
-Created new notes file in releasenotes/notes/remove-ansible-requirements-6c6eba43f616bc6b.yaml
-```
-
-The created file contains prepared entries for several categories. It is described briefly
-in each instance which contents belong in which category. What is not needed is deleted.
-
-```yaml
-prelude: >
-    Replace this text with content to appear at the top of the section for this
-    release. All of the prelude content is merged together and then rendered
-    separately from the items listed in other parts of the file, so the text
-    needs to be worded so that both the prelude and the other items make sense
-    when read independently. This may mean repeating some details. Not every
-    release note requires a prelude. Usually only notes describing major
-    features or adding release theme details should have a prelude.
-features:
-  - |
-    List new features here, or remove this section.  All of the list items in
-    this section are combined when the release notes are rendered, so the text
-    needs to be worded so that it does not depend on any information only
-    available in another section, such as the prelude. This may mean repeating
-    some details.
-issues:
-  - |
-    List known issues here, or remove this section.  All of the list items in
-    this section are combined when the release notes are rendered, so the text
-    needs to be worded so that it does not depend on any information only
-    available in another section, such as the prelude. This may mean repeating
-    some details.
-upgrade:
-  - |
-    List upgrade notes here, or remove this section.  All of the list items in
-    this section are combined when the release notes are rendered, so the text
-    needs to be worded so that it does not depend on any information only
-    available in another section, such as the prelude. This may mean repeating
-    some details.
-deprecations:
-  - |
-    List deprecations notes here, or remove this section.  All of the list
-    items in this section are combined when the release notes are rendered, so
-    the text needs to be worded so that it does not depend on any information
-    only available in another section, such as the prelude. This may mean
-    repeating some details.
-critical:
-  - |
-    Add critical notes here, or remove this section.  All of the list items in
-    this section are combined when the release notes are rendered, so the text
-    needs to be worded so that it does not depend on any information only
-    available in another section, such as the prelude. This may mean repeating
-    some details.
-security:
-  - |
-    Add security notes here, or remove this section.  All of the list items in
-    this section are combined when the release notes are rendered, so the text
-    needs to be worded so that it does not depend on any information only
-    available in another section, such as the prelude. This may mean repeating
-    some details.
-fixes:
-  - |
-    Add normal bug fixes here, or remove this section.  All of the list items
-    in this section are combined when the release notes are rendered, so the
-    text needs to be worded so that it does not depend on any information only
-    available in another section, such as the prelude. This may mean repeating
-    some details.
-other:
-  - |
-    Add other notes here, or remove this section.  All of the list items in
-    this section are combined when the release notes are rendered, so the text
-    needs to be worded so that it does not depend on any information only
-    available in another section, such as the prelude. This may mean repeating
-    some details.
-```
-
-### Example
-
-Here is an example of a [commit from the osism/generics repository](https://github.com/osism/generics/commit/e2f04a9f4a51eb058446d7a8ab6835df53989099).
-
-```yaml
----
-features:
-  - |
-    The `requirements.yml` has been removed. The version will be set in the `run.sh`
-    script for the seed process in the future exactly as later in the update process
-    via the parameters `ANSIBLE_COLLECTION_SERVICES_VERSION` and
-    `ANSIBLE_PLAYBOOKS_MANAGER_VERSION`.
-upgrade:
-  - |
-    In existing configuration repositories, the `environments/manager/requirements.yml`
-    file can be removed after the generics have been synced.
-```
-
-### Repositories without release notes
-
-We do not create release notes in the following repositories:
-
-* osism/github-manager
-* osism/osism.github.io
-* osism/release
+Per-component changelogs are generated from the git history in the
+osism/release repository. This is documented in the
+[README of the osism/release repository](https://github.com/osism/release#release-process).

--- a/docs/guides/developer-guide/releases.md
+++ b/docs/guides/developer-guide/releases.md
@@ -7,19 +7,24 @@ sidebar_position: 10
 
 ## How we handle releases
 
-Currently we do a major release every 6 months. Minor releases we do when
-needed and about every 2 weeks.
+We do one major release per year, anchored on the SLURP (`YYYY.1`) OpenStack
+release and cut about one month after the matching Kolla release. Minor releases
+we do when needed and about every 6 to 8 weeks. See the
+[Release Cadence](../../concepts/release-cadence.md) concept for the full
+cadence and support lifecycle.
 
-In a minor release, only updates, bug fixes, etc. take place. There are also
-no major upgrades of included components such as OpenStack, Keycloak or Ceph
-in a minor release.
+In a minor release, only updates, bug fixes, and security fixes take place. The
+OpenStack version is not upgraded in a minor release; it is tied to the major
+release. Kubernetes (managed with Gardener) and Ceph (managed with cephadm) are
+exceptions — they are not bound to the OSISM major release and can be updated
+independently of it.
 
 It is possible to jump from any minor version within a major version to higher
 minor versions without any intervention.
 
 Deprecations, removals, etc. take place in a major release. New mandatory
-features are also added in a major release. Upgrades of the included components
-can also take place during a major release (e.g. OpenStack Xena -> OpenStack Yoga).
+features are also added in a major release. The upgrade of the OpenStack release
+also happens during a major release (e.g. OpenStack 2025.1 -> OpenStack 2026.1).
 
 It is possible to jump from the previous major version to the next major version.
 It may be that manual intervention is necessary. For example, configuration

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -35,6 +35,7 @@ The release notes for 7.0.3 must then also be taken into account.
 * We comply with the removals, deprecations, etc. of the individual upstream projects used. The release
   notes of the upstream projects used are not included in the OSISM release notes and must be considered
   separately.
+* [Release Cadence](../concepts/release-cadence.md) — how often OSISM releases, which OpenStack releases it supports, and how long each is maintained.
 * [How to use of a specific release in the configuration repository?](../guides/configuration-guide/manager.mdx#stable-release)
 * [How we handle releases?](../guides/developer-guide/releases.md#how-we-handle-releases)
 * [How to prepare and make a release?](../guides/developer-guide/releases.md#how-to-make-a-release)

--- a/docs/release-notes/osism-10.md
+++ b/docs/release-notes/osism-10.md
@@ -14,11 +14,14 @@ Similar to the Ubuntu point release model, the first release of OSISM 10 is inte
 
 :::info
 
-Starting with OSISM 10, a specific OSISM version is no longer tied to a single version of
-Kubernetes, Docker, Ceph, or OpenStack. Instead, multiple versions of these components are
-supported within the same OSISM release. For OSISM 10, this means that both OpenStack 2025.1
-and OpenStack 2025.2 will be supported. OpenStack 2025.2 will be added with one of the next
-releases.
+OSISM 10 supports only OpenStack 2025.1 Epoxy. Following the
+[SLURP-only policy](../concepts/release-cadence.md), OSISM tracks exactly one
+OpenStack release per major version — the spring SLURP release (`YYYY.1`) — so
+the non-SLURP OpenStack 2025.2 Flamingo is not added to OSISM 10.
+
+Kubernetes (managed with Gardener), Docker, and Ceph (managed with cephadm) are
+not tied to a single version within an OSISM major release and can be updated
+independently of it.
 
 :::
 


### PR DESCRIPTION
Part of osism/issues#1372 — this covers the **documentation** for the SLURP-only release cadence; it does not resolve the full issue (open questions on timing, support window, and unmaintained co-maintenance remain).

> [!IMPORTANT]
> **Do not merge yet.** This is a draft to gather **community feedback** first. The release cadence described here is a proposed policy; it needs review and buy-in from the OSISM community (and alignment on the open points below) before it is merged.

## Summary

Adds a new **Release Cadence** concept chapter defining the OSISM release cadence based on observed operator behaviour, and reconciles related docs with it. Implements the SLURP-only direction from osism/issues#1372.

- **New page** `docs/concepts/release-cadence.md`:
  - One major release per year, anchored on the upstream spring **SLURP** (`YYYY.1`) OpenStack release, cut ~1 month after the matching Kolla release (~August).
  - **SLURP-only** support policy — non-SLURP `YYYY.2` releases are built for evaluation/testing only (no supported upgrade path, no security updates).
  - Point-release model: `.0` for new installs/testing, `.1` for the production changeover (within 2 months).
  - OpenStack is tied to the major; **Kubernetes (Gardener)** and **Ceph (cephadm)** are decoupled and advance independently; security fixes ship via rolling Kolla image tags.
  - Support lifecycle: current release + the one before it (Maintained → Extended Maintenance → End of Life).
  - Concrete OSISM ↔ OpenStack SLURP mapping table.
- Wired into the **concepts index** and **release-notes index**, and reconciled the **developer guide** release description.

## Corrects an already-released release note

Corrects `osism-10.md`, which implied OpenStack 2025.2 would be added — kept as a **separate commit** and explicitly marked because it edits a published release note.

## Notes / open points (feedback wanted)

- Release **timing** (~August) reflects the Kolla +1-month formula; this is earlier than issue #1372's stated ~6–9 month / H2 target and OSISM 10's observed ~11-month GA. Kept per maintainer decision — flagging for reviewer awareness.
- The **support window** uses an 18–21 month model (Maintained + Extended Maintenance) rather than the issue's upstream Maintained → Unmaintained → EOL framing; the exact window is still an open question in #1372.

## Verification

- `yarn build` passes with `onBrokenLinks: 'throw'`, so all cross-links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)