### PR TITLE
Review fixes for operator key rotation guide

### DIFF
--- a/docs/guides/operations-guide/operator_key_rotation.md
+++ b/docs/guides/operations-guide/operator_key_rotation.md
@@ -5,7 +5,7 @@ sidebar_label: Rotate Operator Key
 # Rotation of the operator key
 
 The operator key is used to gain access to all nodes managed by the OSISM
-manager and usually also to access the manager itself.
+Manager and usually also to access the manager itself.
 Rotation of the key is a multi-step process.
 
 ## Generating a new key and adding it to the list of authorized keys
@@ -39,19 +39,19 @@ On the manager node:
 * Actually append the new key by applying the operator role. It is advisable to test the change by limiting the rollout to a single node using the `--limit` parameter.
   ```bash
   osism apply operator -- --limit node01
-  ```  
-* Test the new access by explicitly specifying the private key explicitly.
+  ```
+* Test the new access by explicitly specifying the private key.
   ```bash
   ssh -o IdentitiesOnly=yes -i ~/.ssh/id_new_private_key dragon@node01
   ```
-* If the login is successful proceed with the rollout across the fleet.
+* If the login is successful, proceed with the rollout across the fleet.
   ```bash
   osism apply operator
-  ```  
+  ```
 
 ## Preparing the configuration repository to use the new key in the manager
 
-* Replace the content of `operator_private_key` in `environments/secrets.yml` of your configuration repository with the content of the newly created **private** key file. Decrypt and Rencrypt the file using your configuration repositories ansible vault password.
+* Replace the content of `operator_private_key` in `environments/secrets.yml` of your configuration repository with the content of the newly created **private** key file. Decrypt and re-encrypt the file using your configuration repository's Ansible Vault password.
   ```yaml:environments/secrets.yml
   [...]
   configuration_git_private_key: |
@@ -103,30 +103,30 @@ On the manager node:
 * Remove the old key by applying the operator role. It is advisable to test the change by limiting the rollout to a single node using the `--limit` parameter.
   ```bash
   osism apply operator -- --limit node01
-  ```  
+  ```
 * Test whether the manager can still access the node
   ```bash
   osism apply ping -- --limit node01
   ```
-* If the ping is successful proceed with the rollout across the fleet.
+* If the ping is successful, proceed with the rollout across the fleet.
   ```bash
   osism apply operator
   ```
 
-The manager now uses the new key to access the nodes and access for the old key has been revoked.
+The manager now uses the new key to access the nodes, and access for the old key has been revoked.
 
 ## Clean up the configuration repository
 
-Since the old key has been removed and may be removed from the configuration repository as well.
+Since the old key has been removed, it may be removed from the configuration repository as well.
 
 * Remove the key `operator_authorized_keys_delete` in `environments/configuration.yml` of your configuration repository.
 * Commit and push the change to the repository.
 
-## Rotating the key in the NetBox (metalbox)
+## Rotating the key in the NetBox (MetalBox)
 
-In case the hardware is provisioned using the OSISM metalbox the operator key also needs to be replaced the `local_context` of each device, so that a newly provisioned system is accessible through the manager.
-If your setup uses a separate Repository for NetBox management apply the following change there and update the git submodule in the configuration repository afterwards by running `git submodule update --init`. Remember to also commit the updated submodule
-In case your setup manages the NetBox from the configuration directory apply the changes there and commit them directly.
+In case the hardware is provisioned using the OSISM MetalBox, the operator key also needs to be replaced in the `local_context` of each device, so that a newly provisioned system is accessible through the manager.
+If your setup uses a separate repository for NetBox management, apply the following change there and update the git submodule in the configuration repository afterwards by running `git submodule update --init`. Remember to also commit the updated submodule.
+In case your setup manages the NetBox from the configuration directory, apply the changes there and commit them directly.
 
 * Find each occurrence of
   ```yaml
@@ -139,7 +139,7 @@ In case your setup manages the NetBox from the configuration directory apply the
   and replace the old key with the new **public** key.
 * Commit and push the change to the repository.
 
-On your metalbox(es):
+On your MetalBox(es):
 
 * Update the NetBox data in `/opt/configuration` with the change just committed.
 * Manage the local NetBox to update it
@@ -148,7 +148,6 @@ On your metalbox(es):
   ```
 
 Do the same on your manager:
-
 
 * Update the NetBox data in `/opt/configuration` with the change just committed.
   ```bash

--- a/docs/guides/operations-guide/operator_key_rotation.md
+++ b/docs/guides/operations-guide/operator_key_rotation.md
@@ -4,16 +4,22 @@ sidebar_label: Rotate Operator Key
 
 # Rotation of the operator key
 
-The operator key is used to gain access to all nodes managed by the OSISM
-Manager and usually also to access the manager itself.
+The operator key is used by the OSISM Manager to access all nodes it manages,
+including systems provisioned via the MetalBox.
 Rotation of the key is a multi-step process.
 
-## Generating a new key and adding it to the list of authorized keys
+## Generating a new key
 
-* Generate a new ssh key, using `ssh-keygen` or any other tool suiting your
-  requirements
-* Distribute the private key to all jumphosts used to access the manager node
-  with the operator user (usually `dragon`)
+* Generate a new SSH key, for example using `ssh-keygen`:
+  ```bash
+  ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_new_private_key
+  ```
+* Make the new private key available wherever you need it, so that SSH access to
+  the manager, MetalBox and nodes is possible in your environment. The exact
+  location depends on your setup.
+
+## Adding the new public key to the nodes
+
 * Append the **public** key to the list of `operator_authorized_keys` in `environments/configuration.yml` of your configuration repository.
   ```yaml:environments/configuration.yml
   [...]
@@ -23,8 +29,6 @@ Rotation of the key is a multi-step process.
   [...]
   ```
 * Commit and push the change to the repository.
-
-## Adding the new public key to the nodes
 
 On the manager node:
 
@@ -115,9 +119,9 @@ On the manager node:
 
 The manager now uses the new key to access the nodes, and access for the old key has been revoked.
 
-## Clean up the configuration repository
+## Clean up the configuration repository (optional)
 
-Since the old key has been removed, it may be removed from the configuration repository as well.
+This step is optional. Since the old key has been removed from the nodes, it may also be removed from the configuration repository.
 
 * Remove the key `operator_authorized_keys_delete` in `environments/configuration.yml` of your configuration repository.
 * Commit and push the change to the repository.
@@ -125,6 +129,7 @@ Since the old key has been removed, it may be removed from the configuration rep
 ## Rotating the key in the NetBox (MetalBox)
 
 In case the hardware is provisioned using the OSISM MetalBox, the operator key also needs to be replaced in the `local_context` of each device, so that a newly provisioned system is accessible through the manager.
+This step is independent of the rotation described above and can be performed at any time; it only affects systems that are newly provisioned via the MetalBox afterwards.
 If your setup uses a separate repository for NetBox management, apply the following change there and update the git submodule in the configuration repository afterwards by running `git submodule update --init`. Remember to also commit the updated submodule.
 In case your setup manages the NetBox from the configuration directory, apply the changes there and commit them directly.
 

--- a/docs/guides/operations-guide/operator_key_rotation.md
+++ b/docs/guides/operations-guide/operator_key_rotation.md
@@ -58,12 +58,13 @@ On the manager node:
 * Replace the content of `operator_private_key` in `environments/secrets.yml` of your configuration repository with the content of the newly created **private** key file. Decrypt and re-encrypt the file using your configuration repository's Ansible Vault password.
   ```yaml:environments/secrets.yml
   [...]
-  configuration_git_private_key: |
+  operator_private_key: |
     -----BEGIN RSA PRIVATE KEY-----
     [...]
     -----END RSA PRIVATE KEY-----
   [...]
   ```
+* *(Optional)* If you also use the operator key as the deploy key to access your configuration repository, replace the content of `configuration_git_private_key` in `environments/secrets.yml` with the new **private** key as well. In this case you must also update the corresponding deploy key (the **public** key) in the repository settings of your Git hosting platform (for example on GitHub).
 * Move the old public key to `operator_authorized_keys_delete` in `environments/configuration.yml` of your configuration repository. Usually the key is set in `operator_public_key` and only referenced in `operator_authorized_keys`, so the new key needs to be moved there. In the end your configuration should look similar to this:
   ```yaml:environments/configuration.yml
   [...]


### PR DESCRIPTION
This PR targets the `operator_key_rotation` branch of #1034 and addresses the
inline review comments left there, so the feedback can be reviewed as a focused
diff on top of the original change.

## Changes

- **Copy-edit**: fix typos, spelling, punctuation and formatting (e.g.
  `Rencrypt` → `re-encrypt`, `Ansible Vault` casing, missing commas, stray
  trailing whitespace) and align product-name spelling (`MetalBox`,
  `OSISM Manager`).
- **Manager access framing** (L8, L15-16): the operator key is now described as
  the key the OSISM Manager uses to reach the nodes it manages, rather than to
  log into the manager. The recommendation to distribute the private key to all
  jump hosts is replaced with a neutral note leaving key placement to the
  reader's environment.
- **Key generation** (L13-14): add a concrete `ssh-keygen` example and drop the
  vague "suiting your requirements" phrasing.
- **Structure** (L17-25): move the "append the public key and commit/push" step
  into the "Adding the new public key to the nodes" section, consistent with the
  later sections.
- **Optional steps**: mark the configuration-repository clean-up as optional and
  note that rotating the key in the NetBox (MetalBox) is independent and can be
  done at any time.
- **Fixes**: correct the `secrets.yml` example to use `operator_private_key`
  (matching the surrounding text) and add an optional step covering setups that
  reuse the operator key as the configuration repository's deploy key (update
  `configuration_git_private_key` and the public deploy key on the Git hosting
  platform).

Once merged into the `operator_key_rotation` branch these changes flow into #1034.

🤖 Generated with [Claude Code](https://claude.com/claude-code)