### PR TITLE
neutron: document DNS resolution for OVN

### DIFF
--- a/docs/guides/configuration-guide/openstack/neutron.md
+++ b/docs/guides/configuration-guide/openstack/neutron.md
@@ -31,3 +31,38 @@ device MTU requires configuration of physical network devices such as switches a
 The configuration is described in the [Neutron admin guide](https://docs.openstack.org/neutron/latest/admin/config-mtu.html).
 The configuration files are placed under `environments/kolla/files/overlays/neutron/ml2_conf.ini`
 and `environments/kolla/files/overlays/neutron.conf`.
+
+## DNS resolution for instances (OVN)
+
+Neutron resolves the DNS servers it hands to instances in this order, using the
+first one that is set:
+
+1. the subnet's own `dns_nameservers`
+2. the `dns_servers` option in the `[ovn]` section
+3. the DNS resolvers of the host running `neutron-server`
+
+The options are described in the
+[Neutron admin guide](https://docs.openstack.org/neutron/latest/admin/config-dns-res.html).
+Setting `dns_nameservers` per subnet is the recommended approach and takes
+precedence over everything below it.
+
+Note that the third step is not a useful fallback on an OSISM deployment. The
+`osism.commons.resolvconf` role points `/etc/resolv.conf` at the
+`systemd-resolved` stub (`127.0.0.53`) and configures the real upstream
+resolvers in `resolved.conf` instead. Neutron does not filter loopback
+addresses out of that file, and the containers run in the host network
+namespace, so `127.0.0.53` is what gets advertised to instances — where it
+resolves nothing. Instances on a subnet without `dns_nameservers` then have no
+working DNS at all, including internal name resolution.
+
+If your deployment has subnets without their own `dns_nameservers`, set the
+resolvers explicitly in `environments/kolla/files/overlays/neutron/ml2_conf.ini`:
+
+```ini
+[ovn]
+dns_servers = 192.0.2.53,192.0.2.54
+```
+
+Any resolver reachable from the provider network works. Note that
+`neutron_dnsmasq_dns_servers`, which defaults to public resolvers, only applies
+to the ML2/OVS DHCP agent and has no effect on an OVN deployment.


### PR DESCRIPTION
## What

Adds a *DNS resolution for instances (OVN)* section to the Neutron configuration
guide, documenting how Neutron decides which DNS servers instances are handed
and how to set them on an OSISM deployment.

## Why

The precedence itself is upstream-documented — subnet `dns_nameservers`, then
`dns_servers` in the `[ovn]` section, then the resolvers of the host running
`neutron-server`. The third level is the problem: on an OSISM deployment it is
not a useful fallback, and nothing in the guide says so.

`osism.commons.resolvconf` points `/etc/resolv.conf` at the `systemd-resolved`
stub (`127.0.0.53`) and configures the real upstream resolvers in
`resolved.conf` instead. Neutron does not filter loopback addresses out of that
file, and the containers run in the host network namespace, so `127.0.0.53` is
what gets advertised to instances — where it resolves nothing. Instances on a
subnet without `dns_nameservers` therefore end up with no working DNS at all,
including internal name resolution.

## How

- States the three-level precedence and links to the upstream admin guide.
- Names per-subnet `dns_nameservers` as the recommended approach.
- Explains why the host-resolvers level does not work on OSISM, and gives the
  deployment-wide fix: `[ovn] dns_servers` via
  `environments/kolla/files/overlays/neutron/ml2_conf.ini`.
- Notes that `neutron_dnsmasq_dns_servers`, which defaults to public resolvers,
  applies only to the ML2/OVS DHCP agent and has no effect under OVN.

Markdown-only addition to an existing page; `yarn build` has not been run
locally.

## Related

Independent of, but found in the same investigation as:

- #1042

🤖 Generated with [Claude Code](https://claude.com/claude-code)
