### PR TITLE
troubleshooting: document Horizon offline compression error

### DIFF
--- a/docs/guides/troubleshooting-guide/openstack.md
+++ b/docs/guides/troubleshooting-guide/openstack.md
@@ -208,3 +208,54 @@ sidebar_position: 40
     docker exec ovn_nb_db ovs-appctl -t /var/run/ovn/ovnnb_db.ctl cluster/status OVN_Northbound
     docker exec ovn_sb_db ovs-appctl -t /var/run/ovn/ovnsb_db.ctl cluster/status OVN_Southbound
     ```
+
+## Horizon shows "Something went wrong!" after an upgrade
+
+* Problem: Horizon answers with the error page `Something went wrong!` instead of the requested page. Often
+  only a part of the requests is affected, because only some of the control nodes have the problem. On such a
+  node, `/var/log/kolla/horizon/horizon-error.log` contains an `OfflineGenerationError` followed by the
+  complete HTML of the requested page.
+
+  ```console
+  compressor.exceptions.OfflineGenerationError: You have offline compression enabled but key
+  "2ea3a0ed8d1c74d8faae7819d923c890da5126d18db513410ac36f43bbce22b8" is missing from offline manifest.
+  You may need to run "python manage.py compress".
+  ```
+
+  Horizon uses offline compression (`COMPRESS_OFFLINE = True`). With that, the compressed CSS and JavaScript
+  files and an offline manifest, which maps each template fragment to its compressed file, are generated
+  inside the `horizon` container. The container only regenerates them when it starts and the checksum of its
+  settings and themes stored in `/var/lib/kolla/.settings.md5sum.txt` is missing or no longer matches. If the
+  manifest does not belong to the templates of the image that is currently in use, which can happen after an
+  upgrade to a new OSISM release, Horizon does not find the key of a template fragment while rendering a page
+  and aborts with the error above.
+
+* Solution: remove the checksum file and restart the container. The container then regenerates the static
+  files and the offline manifest during the next start, using the same code path as a configuration change.
+  This is the reliable way to fix the error.
+
+  ```console
+  docker exec horizon rm -f /var/lib/kolla/.settings.md5sum.txt
+  docker restart horizon
+  ```
+
+  Generating the files manually inside the container does not always resolve the error and should only be
+  used if removing the checksum file is not possible. Keep this order, `collectstatic --clear` empties the
+  static directory and would delete a manifest that was created before.
+
+  ```console
+  docker exec horizon /var/lib/kolla/venv/bin/python /var/lib/kolla/venv/bin/manage.py collectstatic --noinput --clear
+  docker exec horizon /var/lib/kolla/venv/bin/python /var/lib/kolla/venv/bin/manage.py compress --force
+  docker restart horizon
+  ```
+
+  The restart at the end is necessary because the running Horizon processes keep the offline manifest in
+  memory. `--force` is used because `manage.py` does not always read the local settings when it is called
+  this way and then aborts with `CommandError: Offline compression is disabled.` although
+  `COMPRESS_OFFLINE = True` is set.
+
+  Repeat this on every control node on which Horizon runs. The manifest is only valid inside its own
+  container.
+
+* Do not disable the offline compression with `COMPRESS_OFFLINE = False` to get rid of the error. The error
+  disappears, but afterwards every page is compressed again on each request.

--- a/docs/guides/upgrade-guide/openstack.md
+++ b/docs/guides/upgrade-guide/openstack.md
@@ -100,3 +100,17 @@ of the APIs. This downtime is usually less than 1 minute.
     osism apply -a pull horizon
     osism apply -a upgrade horizon
     ```
+
+    Horizon generates its compressed static files and the offline manifest only when the checksum of its
+    settings and themes has changed. After an upgrade the settings are often unchanged, the new image is
+    then used together with the manifest of the old one and Horizon answers with `Something went wrong!`.
+    To avoid this, remove the checksum file on every control node on which Horizon runs and restart the
+    container afterwards.
+
+    ```bash
+    docker exec horizon rm -f /var/lib/kolla/.settings.md5sum.txt
+    docker restart horizon
+    ```
+
+    Details on this error are documented in the
+    [OpenStack Troubleshooting Guide](../troubleshooting-guide/openstack.md).


### PR DESCRIPTION
Documents the Horizon `OfflineGenerationError` from https://github.com/osism/issues/issues/1363 in the OpenStack troubleshooting guide and adds the corresponding step to the upgrade guide.

After an upgrade Horizon can answer with the `Something went wrong!` error page while `/var/log/kolla/horizon/horizon-error.log` logs that a key is missing from the offline manifest. In the report this appeared after the upgrade to OSISM 10 and only affected a part of the control nodes.

The new section in the troubleshooting guide covers:

* the symptom and where to find the error,
* the cause: the compressed assets and the offline manifest are generated inside the `horizon` container by `extend_start.sh`, but only when the container starts and the checksum in `/var/lib/kolla/.settings.md5sum.txt` is missing or no longer matches,
* the solution: remove the checksum file and restart the container, which regenerates everything through the same code path that runs after a configuration change,
* the manual variant with `collectstatic --noinput --clear` followed by `compress --force` as a fallback, including why that order is required and why a restart is needed afterwards,
* a note that `COMPRESS_OFFLINE = False` only hides the problem.

The order of the two `manage.py` calls differs from the suggestion in the issue: `collectstatic --clear` empties the static directory and would delete a manifest created before it, so it has to run first. This matches `docker/horizon/extend_start.sh` in kolla.

Feedback on an earlier version of this pull request in https://github.com/osism/issues/issues/1363#issuecomment-5117519922 is included:

* The manual variant did not resolve the error in the reported case, while removing (renaming) the checksum file and restarting the container did. Both were documented as equivalent alternatives before. Removing the checksum file is now the solution, and the manual variant is marked as a fallback that does not always resolve the error and should only be used if the checksum file cannot be removed.
* As suggested there, the step is carried out as part of the upgrade instead of only after the error has appeared. The Horizon step of the upgrade guide gets the removal of the checksum file and the restart of the container, together with the reason: after an upgrade the settings are often unchanged, so the checksum still matches, no regeneration happens and the new image is used with the manifest of the old one. The step points to the troubleshooting guide for the details.

Doing this in the Horizon role or the upgrade playbook, so that `osism apply -a upgrade horizon` takes care of it on its own, would be preferable to a manual step. That is a change outside of this repository.

Paths, the log file name and the regeneration mechanism were checked against `stable/2025.1` of kolla and kolla-ansible.
