### PR TITLE
release-notes: sort the sidebar entries by version

### DIFF
--- a/docs/release-notes/osism-10.md
+++ b/docs/release-notes/osism-10.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: OSISM 10
+sidebar_position: 10
 ---
 
 # OSISM 10

--- a/docs/release-notes/osism-7.md
+++ b/docs/release-notes/osism-7.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: OSISM 7
+sidebar_position: 40
 ---
 
 # OSISM 7

--- a/docs/release-notes/osism-8.md
+++ b/docs/release-notes/osism-8.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: OSISM 8
+sidebar_position: 30
 ---
 
 # OSISM 8

--- a/docs/release-notes/osism-9.md
+++ b/docs/release-notes/osism-9.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: OSISM 9
+sidebar_position: 20
 ---
 
 # OSISM 9


### PR DESCRIPTION
The release notes in the sidebar on https://osism.tech/docs/release-notes/ were
listed as 10, 7, 8, 9 instead of 10, 9, 8, 7.

The sidebar is generated from the file system via the autogenerated sidebar in
`sidebars.js`. None of the release notes pages carried a `sidebar_position`, so
Docusaurus fell back to sorting the entries alphabetically by their label, which
put OSISM 10 in front of OSISM 7.

This adds an explicit `sidebar_position` to the four pages, in steps of 10 as
used everywhere else in the docs tree:

| Page | `sidebar_position` |
|:--|:--|
| `osism-10.md` | 10 |
| `osism-9.md` | 20 |
| `osism-8.md` | 30 |
| `osism-7.md` | 40 |

A new major release has to claim a position below the one of the current newest
series, or the existing pages have to be renumbered.

Verified with `yarn docusaurus build --locale en`: the sidebar in the generated
`build/docs/release-notes/index.html` now lists OSISM 10, 9, 8, 7. The `i18n`
tree only contains the `en` locale and no copies of these pages, so no
translations are affected.