### PR TITLE
Add OSSA-2026-032 security advisory for Neutron

### DIFF
--- a/docs/appendix/security/index.md
+++ b/docs/appendix/security/index.md
@@ -32,3 +32,4 @@ handling of security-related information.
 | [OSSA-2026-005](ossa-2026-005.md) | Restricted app credentials can create EC2 credentials | OpenStack Keystone           |
 | [OSSA-2026-015](ossa-2026-015.md) | Credential delegation and authorization bypass issues | OpenStack Keystone           |
 | [OSSA-2026-022](ossa-2026-022.md) | Scheduler hint injection bypasses Placement claims    | OpenStack Nova               |
+| [OSSA-2026-032](ossa-2026-032.md) | Cross-project subnet mutation via subnetpool onboard  | OpenStack Neutron            |

--- a/docs/appendix/security/ossa-2026-032.md
+++ b/docs/appendix/security/ossa-2026-032.md
@@ -92,6 +92,12 @@ The severity of a successful attack depends on the deployment:
   affected subnets, and disrupt routing — particularly in deployments using DVR or address
   scope–aware floating IP handling.
 
+The address scope is not an attribute of the subnet. A subnet only carries a `subnetpool_id`, the
+subnetpool carries the `address_scope_id`, and the resulting scope is exposed on the **network** as
+`ipv4_address_scope` and `ipv6_address_scope`. A successful attack is therefore not visible in
+`openstack subnet show` beyond the changed `subnetpool_id` — the change of the address scope only
+shows up on the network.
+
 ### How to Check if You Are Affected
 
 #### Check the Running Neutron Version
@@ -129,11 +135,15 @@ Any network returned here that is not owned by the project using it can be used 
 #### Assess the Potential Blast Radius
 
 ```bash
+# Address scopes that exist in the deployment
 openstack address scope list
+
+# Subnetpools and the address scope they are attached to
+openstack subnet pool list --long -c ID -c Name -c "Address Scope" -c Shared
 ```
 
 If address scopes are in use, a successful attack can affect routing and NAT, not just subnet
-metadata.
+metadata. Only subnetpools with an address scope can be used for the second, more severe variant.
 
 ## Vulnerability Details
 
@@ -215,11 +225,21 @@ Additional measures worth considering:
 
 1. Reviewing shared networks and `access_as_shared` RBAC policies, and removing shares that are not
    required
-2. Auditing subnets for unexpected `subnetpool_id` or address scope values, in particular on shared
-   and external networks:
+2. Auditing subnets for an unexpected `subnetpool_id` and networks for an unexpected address scope,
+   in particular on shared and external networks. Both values need separate queries: the subnet list
+   does not include the subnetpool, and the address scope is only available on the network.
    ```bash
-   openstack subnet list --long -c ID -c Name -c Network -c Subnetpool
+   # Subnets per subnetpool, including the owning project
+   for pool in $(openstack subnet pool list -f value -c ID); do
+       echo "subnetpool ${pool}"
+       openstack subnet list --subnet-pool "${pool}" --long -f value -c ID -c Name -c Project
+   done
+
+   # Address scopes of a network (not visible on the subnet)
+   openstack network show <network> -c ipv4_address_scope -c ipv6_address_scope
    ```
+   A subnet whose project does not match the project of its subnetpool is an indication of an
+   onboarding that has taken place across project boundaries.
 3. Monitoring the Neutron API logs for `onboard_network_subnets` calls
 
 ## References

--- a/docs/appendix/security/ossa-2026-032.md
+++ b/docs/appendix/security/ossa-2026-032.md
@@ -1,0 +1,235 @@
+---
+sidebar_label: OSSA-2026-032
+---
+
+# OSSA-2026-032: Cross-project subnet mutation via Neutron subnetpool onboarding
+
+| Property         | Value                                                             |
+|:-----------------|:------------------------------------------------------------------|
+| Date             | 2026-07-29                                                        |
+| CVE              | [CVE-2026-55707](https://www.cve.org/CVERecord?id=CVE-2026-55707) |
+| Severity         | High                                                              |
+| Affected Project | Neutron                                                           |
+| Reporter         | Tim Shephard (roiai.ca)                                           |
+
+## Summary
+
+A vulnerability was discovered in OpenStack Neutron where the subnetpool onboarding API,
+`PUT /v2.0/subnetpools/{id}/onboard_network_subnets`, only checks that the caller can *see* the
+target network, not that the caller *owns* it. An authenticated project member who can see a
+network belonging to another project can therefore onboard that network's subnets into a subnetpool
+of their own, rewriting the victim's persistent subnet state and — where address scopes are in use —
+altering L3 routing, NAT, and floating IP behaviour for the victim's routers.
+
+Exploitation requires an authenticated user with the `member` role, a subnetpool in the attacker's
+own project, and a network of another project that is visible to the attacker. The subnetpool
+onboarding extension itself is part of the ML2 plugin's default extension set and is therefore
+enabled in every OSISM deployment.
+
+Upstream has not published a CVSS score for this issue. The severity rating above is OSISM's
+assessment: it is an unauthenticated-by-design cross-project authorization bypass with high
+integrity and availability impact on the victim's networking, but its practical blast radius
+depends on whether the deployment uses address scopes (see [Impact on OSISM](#impact-on-osism)).
+
+## Affected Versions
+
+All released Neutron versions from 14.0.0 (Stein) onwards are affected. The subnetpool onboarding
+feature was introduced in Stein and has never carried an ownership check.
+
+**At the time of this advisory there is no fixed Neutron release available upstream for any
+series.** The upstream fixes are still under review on OpenDev and have not merged yet.
+
+| OpenStack Release      | Latest Released Neutron Version | Upstream Status                                    |
+|:-----------------------|:--------------------------------|:---------------------------------------------------|
+| Caracal (2024.1)       | 24.2.2                          | Vulnerable — unmaintained, no upstream fix         |
+| Dalmatian (2024.2)     | 25.2.3                          | Vulnerable — end of life since 2026-04-29, no fix  |
+| Epoxy (2025.1)         | 26.0.5                          | Vulnerable — fix proposed (26.0.6), not yet merged |
+| Flamingo (2025.2)      | 27.0.3                          | Vulnerable — fix proposed (27.0.4), not yet merged |
+| Gazpacho (2026.1)      | 28.0.1                          | Vulnerable — fix proposed (28.0.2), not yet merged |
+| Hibiscus (2026.2, dev) | —                               | Fix proposed on master, not yet merged             |
+
+The upstream advisory states the affected ranges as `>=14.0.0 <26.0.6`, `>=27.0.0 <27.0.4` and
+`>=28.0.0 <28.0.2`, so the fixes are expected in Neutron 26.0.6 (Epoxy), 27.0.4 (Flamingo) and
+28.0.2 (Gazpacho).
+
+Caracal (2024.1) is unmaintained and Dalmatian (2024.2) reached end of life on 2026-04-29 upstream;
+neither will receive an official fixed release.
+
+OSISM already ships container images with the fix backported as downstream patches for all supported
+OpenStack releases — 2024.1 (Caracal), 2024.2 (Dalmatian), 2025.1 (Epoxy), and 2025.2 (Flamingo) —
+and these patched images are available now. For Epoxy and Flamingo the images carry the proposed
+upstream patch ahead of its official upstream release; for Caracal and Dalmatian, which will receive
+no official upstream fix, OSISM provides community-curated backports.
+
+## Impact on OSISM
+
+Every OSISM deployment runs the ML2 core plugin, which enables the `subnet_onboard` API extension by
+default. There is no OSISM configuration that disables it, so the vulnerable endpoint is exposed in
+all deployments.
+
+Whether the endpoint can actually be abused depends on whether a project can see a network it does
+not own. Neutron makes a network visible to a non-owning project in three cases:
+
+- the network is marked **shared** (`--share`),
+- the network is shared with the project through a **network RBAC policy**
+  (`access_as_shared`),
+- the network is an **external** network — Neutron's query hooks expose external networks to every
+  project, so the external/floating IP network of a deployment is reachable through this code path
+  as well.
+
+The last case applies to practically every OSISM deployment, since an external network is required
+for floating IPs. The upstream advisory scopes the issue to shared and RBAC-shared networks; the
+inclusion of external networks is OSISM's own assessment of the affected code path.
+
+The severity of a successful attack depends on the deployment:
+
+- **Without address scopes**, the attacker rewrites the `subnetpool_id` of the victim's subnets.
+  This corrupts prefix accounting, can block the owner from further subnet operations, and can cause
+  allocation conflicts — an integrity and availability problem for the victim project.
+- **With address scopes**, the onboarded subnets additionally inherit the address scope of the
+  attacker's subnetpool. Neutron publishes a `SUBNETPOOL_ADDRESS_SCOPE` update, and the victim's
+  routers are reconfigured accordingly. This can change SNAT behaviour, break or bypass NAT for the
+  affected subnets, and disrupt routing — particularly in deployments using DVR or address
+  scope–aware floating IP handling.
+
+### How to Check if You Are Affected
+
+#### Check the Running Neutron Version
+
+```bash
+docker exec neutron_server pip show neutron 2>/dev/null | grep -i '^Version'
+```
+
+Because no fixed Neutron release exists upstream yet, your deployment is **affected** unless you
+have deployed an OSISM container image that includes the backported fix (see Remediation).
+
+#### Check That the Extension Is Enabled
+
+```bash
+openstack extension list --network -f value -c Alias | grep -x subnet_onboard
+```
+
+A match confirms the vulnerable endpoint is exposed. This is the default for all OSISM deployments.
+
+#### Check for Networks Visible Across Project Boundaries
+
+```bash
+# Shared networks
+openstack network list --share -f value -c ID -c Name
+
+# Networks shared through RBAC policies
+openstack network rbac list --type network --action access_as_shared
+
+# External networks (visible to every project)
+openstack network list --external -f value -c ID -c Name
+```
+
+Any network returned here that is not owned by the project using it can be used as a target.
+
+#### Assess the Potential Blast Radius
+
+```bash
+openstack address scope list
+```
+
+If address scopes are in use, a successful attack can affect routing and NAT, not just subnet
+metadata.
+
+## Vulnerability Details
+
+The subnetpool onboarding API allows a project to adopt the existing subnets of a network into one of
+its subnetpools. The implementation in `NeutronDbPluginV2.onboard_network_subnets()`
+(`neutron/db/db_base_plugin_v2.py`) validated the request as follows:
+
+1. `network_id` must be set.
+2. `self._network_exists(context, network_id)` must return the network.
+3. The referenced subnetpool must exist.
+
+Step 2 is a *visibility* check, not an *ownership* check: `_network_exists()` runs a query with
+Neutron's standard result hooks, which deliberately return shared, RBAC-shared, and external networks
+to non-admin callers. No check compared the caller's `project_id` against the network's owner, so any
+project that could see the network could onboard its subnets.
+
+The onboarding itself then updates the subnets in place — setting their `subnetpool_id` to the
+attacker's pool — and, if that pool has an address scope, publishes a `SUBNETPOOL_ADDRESS_SCOPE`
+`AFTER_UPDATE` event so that all affected routers are reconfigured. Both the subnet mutation and the
+router reconfiguration happen on resources belonging to the victim project.
+
+The fix adds an explicit ownership check before any mutation takes place. Non-admin callers must own
+the network; otherwise the request is rejected with `NotAuthorized`:
+
+```python
+# Prevent cross-project subnet mutation: non-admin callers must own
+# the network to onboard its subnets. Without this check a caller
+# with visibility to a shared/RBAC network can reassign subnets
+# owned by another project to their own subnetpool, potentially
+# altering address-scope and L3 routing state for victim routers.
+if not context.is_admin:
+    network = network_obj.Network.get_object(
+        context.elevated(), id=network_id)
+    if network.project_id != context.project_id:
+        raise exc.NotAuthorized()
+```
+
+Administrators retain the ability to onboard subnets from any network.
+
+## Remediation
+
+### For OSISM Releases
+
+Because no fixed Neutron release is available upstream, OSISM provides the fix as downstream patches
+for the Neutron container images via the following change:
+
+- [container-images-kolla commit a6a81b4](https://github.com/osism/container-images-kolla/commit/a6a81b496d749670e6f495ca1e65ae2dcad262dc)
+  ([PR #758](https://github.com/osism/container-images-kolla/pull/758))
+
+This change adds the patch for all four supported releases (2024.1, 2024.2, 2025.1, 2025.2).
+
+A fix will be included in upcoming OSISM releases that ship the patched Neutron container images.
+Consult the [OSISM Release Notes](../../release-notes/) for version information and availability.
+
+The vulnerable code path runs in the Neutron API service, so it is sufficient to override the
+`neutron-server` container image. Using rolling tags, configure the following in
+`environments/kolla/images.yml`:
+
+```yaml
+neutron_server_tag: "2025.1"  # or "2024.1", "2024.2", "2025.2", depending on your OpenStack release
+```
+
+The Neutron agent images (`neutron-openvswitch-agent`, `neutron-l3-agent`, and others) do not contain
+the affected code and do not need to be updated for this issue.
+
+### Mitigation
+
+Until the patched container image is deployed, the endpoint can be restricted to administrators
+through a policy override. Add the following to `/etc/kolla/config/neutron/policy.yaml`:
+
+```yaml
+"onboard_network_subnets": "rule:context_is_admin"
+```
+
+This blocks the vulnerable code path completely. It also removes subnetpool onboarding for regular
+projects, so only apply it if the feature is not used by your tenants.
+
+Additional measures worth considering:
+
+1. Reviewing shared networks and `access_as_shared` RBAC policies, and removing shares that are not
+   required
+2. Auditing subnets for unexpected `subnetpool_id` or address scope values, in particular on shared
+   and external networks:
+   ```bash
+   openstack subnet list --long -c ID -c Name -c Network -c Subnetpool
+   ```
+3. Monitoring the Neutron API logs for `onboard_network_subnets` calls
+
+## References
+
+- [OpenDev Review (OSSA-2026-032 Advisory)](https://review.opendev.org/c/openstack/ossa/+/999139)
+- [OSISM Fix (container-images-kolla commit a6a81b4)](https://github.com/osism/container-images-kolla/commit/a6a81b496d749670e6f495ca1e65ae2dcad262dc)
+- [OSISM Fix (container-images-kolla PR #758)](https://github.com/osism/container-images-kolla/pull/758)
+- [OpenDev Review (Proposed Fix - Hibiscus)](https://review.opendev.org/999131)
+- [OpenDev Review (Proposed Fix - Gazpacho)](https://review.opendev.org/999132)
+- [OpenDev Review (Proposed Fix - Flamingo)](https://review.opendev.org/999133)
+- [OpenDev Review (Proposed Fix - Epoxy)](https://review.opendev.org/999134)
+- [Launchpad Bug #2152113](https://bugs.launchpad.net/neutron/+bug/2152113)
+- [CVE-2026-55707](https://www.cve.org/CVERecord?id=CVE-2026-55707)


### PR DESCRIPTION
Documents the cross-project subnet mutation via Neutron's subnetpool onboarding API
([CVE-2026-55707](https://www.cve.org/CVERecord?id=CVE-2026-55707), [LP #2152113](https://bugs.launchpad.net/neutron/+bug/2152113)).

`PUT /v2.0/subnetpools/{id}/onboard_network_subnets` only checks that the caller can *see* the
target network, not that it *owns* it. A project member can therefore onboard another project's
subnets into their own subnetpool, rewriting the victim's persistent subnet state and — where
address scopes are in use — altering L3 routing, NAT and floating IP behaviour for the victim's
routers.

No upstream Neutron release is fixed yet and all four upstream reviews ([999131](https://review.opendev.org/999131),
[999132](https://review.opendev.org/999132), [999133](https://review.opendev.org/999133),
[999134](https://review.opendev.org/999134)) are still open. OSISM ships the backported fix for
2024.1, 2024.2, 2025.1 and 2025.2 via [container-images-kolla PR #758](https://github.com/osism/container-images-kolla/pull/758).
Overriding `neutron_server_tag` is sufficient, since the affected code path runs in the Neutron API
service; a policy override on `onboard_network_subnets` works as an interim mitigation.

Two points that go beyond the upstream advisory text and are marked as OSISM's own assessment in
the document:

- The `subnet_onboard` extension is part of the ML2 plugin's default extension set, so the endpoint
  is exposed in every OSISM deployment — there is no configuration that disables it.
- The upstream advisory scopes the issue to shared and RBAC-shared networks. `_network_exists()`
  uses `query_with_hooks`, and `external_net_db` registers a result filter that exposes external
  networks to every project, so the external/floating IP network is reachable through the same code
  path.

The upstream advisory is approved (CR+2, W+1) but not yet published, so the references point at the
Gerrit change rather than `security.openstack.org`. Worth swapping once the page exists. The version
range reflects patchset 2, which corrected the Epoxy fix version from 26.0.5 to 26.0.6.

Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhKtmYnNCuyn3cDnSzVKXR
