### PR TITLE
Import MetalBox documentation from its README

### DIFF
--- a/docs/concepts/metalbox.md
+++ b/docs/concepts/metalbox.md
@@ -129,9 +129,10 @@ its initial state (most notably the OSISM Manager image). It is then filled and
 kept up to date from registry tarballs hosted on the OSISM S3 storage. Two
 variants are published — a rolling `2025.1` build and a pinned `stable` build —
 and they are produced automatically by Zuul. See
-[Container registry tarballs](https://github.com/osism/metalbox/tree/main#container-registry-tarballs)
-in the metalbox repository for the available artifacts and the procedure to
-import them.
+[Container registry tarballs](../guides/deploy-guide/metalbox.md#container-registry-tarballs)
+for the available artifacts, and
+[Update of the container registry](../guides/upgrade-guide/metalbox/data-updates.md#update-of-the-container-registry)
+for the procedure to import them.
 
 ### APT repository
 
@@ -142,9 +143,10 @@ as a fallback. All CloudPod nodes use it as their APT source during deployment
 and operations.
 
 Like the container registry, the APT repository is populated from a tarball
-hosted on the OSISM S3 storage. For the available artifacts and the procedure to
-enable, disable, or update the repository, see the
-[metalbox documentation](https://github.com/osism/metalbox/tree/main#readme).
+hosted on the OSISM S3 storage. For the procedure to import the tarball, see
+[Using the MetalBox as an Ubuntu repository server](../guides/deploy-guide/metalbox.md#ubuntu-repository-server);
+for updating it, see
+[Update of the Ubuntu repository files](../guides/upgrade-guide/metalbox/data-updates.md#update-of-the-ubuntu-repository-files).
 
 ### Base services (DHCP, DNS, NTP)
 
@@ -226,8 +228,12 @@ The provisioning sequence is:
 
 ## Further reading
 
-For installing, operating, and updating a MetalBox — including the air-gap
-procedures and the data-update workflows — see the
+For installing a MetalBox — including the air-gap procedures — see
+[Installation of the MetalBox](../guides/deploy-guide/metalbox.md) in the Deploy
+Guide. For keeping it up to date, see
+[Data updates](../guides/upgrade-guide/metalbox/data-updates.md) and
+[Service updates](../guides/upgrade-guide/metalbox/service-updates.md) in the
+Upgrade Guide. The MetalBox itself is developed in the
 [metalbox repository](https://github.com/osism/metalbox).
 
 For populating NetBox from a netbox-configuration repository, see the

--- a/docs/guides/configuration-guide/baremetal/index.md
+++ b/docs/guides/configuration-guide/baremetal/index.md
@@ -1,5 +1,0 @@
----
-sidebar_label: Baremetal
----
-
-# Baremetal

--- a/docs/guides/configuration-guide/metalbox/index.md
+++ b/docs/guides/configuration-guide/metalbox/index.md
@@ -1,0 +1,13 @@
+---
+sidebar_label: MetalBox
+sidebar_key: configuration-guide-metalbox
+---
+
+# MetalBox
+
+* [Software RAID](./software-raid.md) — configure a software RAID for a bare-metal node
+  that is provisioned via Ironic.
+
+The installation of a MetalBox is described in the
+[Deploy Guide](../../deploy-guide/metalbox.md), its architecture in the
+[OSISM MetalBox](../../../concepts/metalbox.md) concept.

--- a/docs/guides/configuration-guide/metalbox/software-raid.md
+++ b/docs/guides/configuration-guide/metalbox/software-raid.md
@@ -1,0 +1,93 @@
+---
+sidebar_label: Software RAID
+sidebar_position: 10
+---
+
+# Software RAID
+
+Configuring a node with software RAID is done by setting an appropriate
+`target_raid_config` in the `ironic_parameters` custom field of the corresponding
+NetBox device.
+
+```yaml
+---
+- device:
+    name: node101
+    [...]
+    custom_fields:
+      [...]
+      ironic_parameters:
+        [...]
+        target_raid_config:
+          logical_disks:
+            - size_gb: MAX
+              raid_level: "1"
+              is_root_volume: true
+              controller: software
+```
+
+Use `osism sync ironic node101` to synchronize the `target_raid_config` with the
+bare-metal node. The RAID configuration is applied during node provisioning with
+`osism baremetal deploy node101`.
+
+The above example configuration creates a software RAID1 as root volume using the full
+size of all available disks. It is possible to restrict the used physical disks by
+specifying the `physical_disks` attribute with an array of restrictions as described in
+the Ironic documentation on
+[root device hints](https://docs.openstack.org/ironic/latest/install/advanced.html#root-device-hints).
+For example use
+
+```yaml
+---
+- device:
+    name: node101
+    [...]
+    custom_fields:
+      [...]
+      ironic_parameters:
+        [...]
+        target_raid_config:
+          logical_disks:
+            - size_gb: MAX
+              raid_level: "1"
+              is_root_volume: true
+              controller: software
+              physical_disks:
+                - size: "<= 1000"
+                - size: "<= 1000"
+```
+
+to restrict usage to two disks with a size smaller than or equal to 1000 GiB.
+
+More examples and restrictions may be found in the
+[Ironic RAID documentation](https://docs.openstack.org/ironic/latest/admin/raid.html).
+
+A generic `target_raid_config` for all nodes may also be added to
+`/opt/configuration/environments/manager/files/conductor.yml` on the MetalBox. This
+however requires a reconfiguration of the Manager running on the MetalBox by executing
+`update-manager.sh`. The change naturally needs to be reapplied when the MetalBox image
+is replaced. Individual nodes with a differing `target_raid_config` may be overridden in
+the NetBox device's custom field `ironic_parameters` as described above.
+
+## Configuring rebuild speed limits for nodes with software RAID
+
+To configure the rebuild speed, `mdraid` provides the `speed_limit_min` and
+`speed_limit_max` sysctl parameters. These may be used to configure a target rebuild
+speed minimum for when there is no rebuild activity on an array and a maximum for when
+there is no other activity. The given values are interpreted as Kibibytes per second.
+
+Use the [sysctl role](../commons/sysctl.md) supplied with OSISM to modify these
+parameters. For example, to set a minimum target speed of `5000 KiB/s` and a maximum
+target speed of `500000 KiB/s` on all nodes in the compute group add the following to
+`environments/generic/configuration.yml`.
+
+```yaml
+sysctl_extra:
+  compute:
+    - name: dev.raid.speed_limit_min
+      value: 5000
+    - name: dev.raid.speed_limit_max
+      value: 500000
+```
+
+The `sysctl` values are then applied by running `osism apply sysctl`.

--- a/docs/guides/deploy-guide/index.md
+++ b/docs/guides/deploy-guide/index.md
@@ -22,3 +22,8 @@ What a configuration repository is and how it is created is described in the
 * Step 5: [Bootstrap of the bare-metal nodes](./bootstrap.md)
 * Step 6: [Deployment of the services](./services/index.md)
 
+If the bare-metal nodes of the cluster are provisioned with an
+[OSISM MetalBox](../../concepts/metalbox.md), the MetalBox itself is installed before
+these steps. Its installation is described in
+[Installation of the MetalBox](./metalbox.md).
+

--- a/docs/guides/deploy-guide/metalbox.md
+++ b/docs/guides/deploy-guide/metalbox.md
@@ -1,0 +1,420 @@
+---
+sidebar_label: MetalBox
+sidebar_position: 5
+---
+
+# Installation of the MetalBox
+
+:::info
+
+For the architecture of the MetalBox and the purpose of its individual components —
+NetBox, the OSISM Manager, Ironic, the HTTPd, the container registry, the APT
+repository, and the base services — see the
+[OSISM MetalBox](../../concepts/metalbox.md) concept.
+
+:::
+
+There are two ways to install a MetalBox:
+
+* **MetalBox image** — a preconfigured machine image is written to the first disk of a
+  physical server. After the initial downloads have been made, the complete
+  installation can be carried out in an air-gapped environment without any access to
+  external sources. This is the recommended way.
+* **Existing server or VM** — the MetalBox services are deployed on an existing
+  Ubuntu 24.04 machine, which can be either a physical server or a virtual machine.
+  This installation requires external connectivity, as packages, container images, and
+  the configuration repository are fetched from the Internet.
+
+## Prerequisites
+
+* A **NetBox configuration repository** that describes the site: the MetalBox itself,
+  the bare-metal nodes, the switches, and the addressing. The data is applied to
+  NetBox with the [netbox-manager](https://github.com/osism/netbox-manager). The
+  MetalBox reads everything it needs to know about the environment from NetBox.
+* Enough **local storage** for the container registry, the Ubuntu repository, and the
+  Ironic images if the environment is air-gapped.
+
+All scripts referenced on this page are part of the MetalBox configuration repository.
+They are located in `/opt/configuration/scripts` and are available on the `PATH` of
+the `dragon` user, so they can be called by their plain name.
+
+## Release variants {#release-variants}
+
+For the container registry two variants are available:
+
+* **2025.1** — a rolling build of the current `2025.1` release. The images are rebuilt
+  and republished regularly, so the tags inside `registry-2025.1-full.tar.bz2` move
+  forward over time.
+* **stable** — always points to the current stable OSISM release (currently OSISM
+  `10.0.0` on kolla `2025.1`; future releases such as `10.1.0` will be published under
+  the same `stable` name). The image versions inside `registry-stable-full.tar.bz2`
+  are pinned per release and only change when a new stable OSISM release is published.
+  Use this variant for reproducible deployments that should not track the rolling
+  `2025.1` build.
+
+The following sections default to the `2025.1` artifacts. Replace the file name with
+the `stable` counterpart (e.g. `registry-stable-full.tar.bz2` instead of
+`registry-2025.1-full.tar.bz2`) to deploy the pinned variant.
+
+:::note
+
+Only the full container registry is provided as a `stable` variant. The non-full
+registry is published as a single version-independent `registry.tar.bz2`. The Octavia
+image (`octavia-export-2025.1.img`) is only published for `2025.1`.
+
+:::
+
+### Container registry tarballs {#container-registry-tarballs}
+
+Four tarballs are published, all built from
+[`zuul/mirror-container-images.yml`](https://github.com/osism/metalbox/blob/main/zuul/mirror-container-images.yml)
+using the image lists under
+[`zuul/vars/`](https://github.com/osism/metalbox/tree/main/zuul/vars).
+
+| Tarball                        | Contents                                                                                                                                                                                                                                                                                                                                                                                                               |
+|:-------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `registry.tar.bz2`             | Version-independent base tarball for the MetalBox itself. Built from [`container-images-metalbox.yml`](https://github.com/osism/metalbox/blob/main/zuul/vars/container-images-metalbox.yml) only.                                                                                                                                                                                                                      |
+| `registry-2024.2-full.tar.bz2` | Contents of `registry.tar.bz2` plus the OpenStack image set from [`container-images-openstack-2024.2.yml`](https://github.com/osism/metalbox/blob/main/zuul/vars/container-images-openstack-2024.2.yml).                                                                                                                                                                                                               |
+| `registry-2025.1-full.tar.bz2` | Contents of `registry.tar.bz2` plus the OpenStack image set from [`container-images-openstack-2025.1.yml`](https://github.com/osism/metalbox/blob/main/zuul/vars/container-images-openstack-2025.1.yml).                                                                                                                                                                                                               |
+| `registry-stable-full.tar.bz2` | Contents of `registry.tar.bz2` plus the OpenStack image set from [`container-images-openstack-stable.yml`](https://github.com/osism/metalbox/blob/main/zuul/vars/container-images-openstack-stable.yml) and the Manager image set from [`container-images-manager-stable.yml`](https://github.com/osism/metalbox/blob/main/zuul/vars/container-images-manager-stable.yml), pinned to the current OSISM stable release. |
+
+## Option 1: Installation from the MetalBox image {#option-1-metalbox-image}
+
+This option requires a **physical server** with a BMC that supports mounting virtual
+media (vHDD and vDVD), connected to the out-of-band (OOB) management network of the
+pod.
+
+### Preparation
+
+1. Download the MetalBox image
+   [osism-metalbox-image.zip](https://nbg1.your-objectstorage.com/osism/openstack-ironic-images/osism-metalbox-image.zip).
+   Unzip the `osism-metalbox-image.zip` file. The unzipped file is named
+   `osism-metalbox-image.raw`.
+2. Download the latest small [Grml](https://grml.org/download/) live ISO file. When
+   creating this document, the file name was `grml-small-2025.05-amd64.iso`.
+3. If SONiC is to be used: Download the SONiC export image `sonic-export.img` from the
+   well known URL. This file can also be created locally by running `sonic-export.sh`
+   inside a directory containing the SONiC images.
+4. Export the NetBox configuration repository with
+   `netbox-manager export-archive -i`. When using a NetBox configuration repository
+   provided by OSISM, the file `netbox-export.img` can be downloaded from GitHub after
+   a trigger of the `Run export` action.
+5. Download the Ironic images:
+   * [osism-ipa.initramfs](https://nbg1.your-objectstorage.com/osism/openstack-ironic-images/osism-ipa.initramfs)
+   * [osism-ipa.kernel](https://nbg1.your-objectstorage.com/osism/openstack-ironic-images/osism-ipa.kernel)
+   * [osism-node.qcow2](https://nbg1.your-objectstorage.com/osism/openstack-ironic-images/osism-node.qcow2)
+   * [osism-node.qcow2.CHECKSUM](https://nbg1.your-objectstorage.com/osism/openstack-ironic-images/osism-node.qcow2.CHECKSUM)
+   * [osism-esp.raw](https://nbg1.your-objectstorage.com/osism/openstack-ironic-images/osism-esp.raw)
+
+:::tip
+
+Downloads from the Hetzner Object Storage can occasionally be interrupted. Use
+`aria2c` for resumable, multi-connection downloads as described in the
+[Troubleshooting Guide](../troubleshooting-guide/metalbox.md#resumable-downloads-with-aria2c).
+
+:::
+
+#### Additional downloads for air-gapped environments
+
+1. If the MetalBox is to be used as an Ubuntu repository server for nodes inside the
+   CloudPod, download
+   [ubuntu-noble.tar.bz2](https://nbg1.your-objectstorage.com/osism/metalbox/ubuntu-noble.tar.bz2).
+2. If the MetalBox is to be used as a container registry for nodes inside the
+   CloudPod, download
+   [registry-2025.1-full.tar.bz2](https://nbg1.your-objectstorage.com/osism/metalbox/registry-2025.1-full.tar.bz2)
+   or, for the pinned variant,
+   [registry-stable-full.tar.bz2](https://nbg1.your-objectstorage.com/osism/metalbox/registry-stable-full.tar.bz2).
+3. If the MetalBox is to be used as a file server for nodes inside the CloudPod,
+   download
+   [octavia-export-2025.1.img](https://nbg1.your-objectstorage.com/osism/metalbox/octavia-export-2025.1.img).
+
+### Writing the image to disk
+
+1. Use the `osism-metalbox-image.raw` file as virtual media (vHDD).
+2. Use the `grml-small-2025.05-amd64.iso` file as virtual media (vDVD) and boot it.
+3. Write the MetalBox image to the first disk. Note that the exact names of the disks
+   may vary depending on the server type, use `lsblk` to verify.
+
+   ```bash
+   dd if=/dev/sdc of=/dev/sda bs=4M status=progress
+   ```
+
+   Afterwards power off the node, remove all virtual media devices and power on the
+   node again.
+
+:::note
+
+The initial boot can take some time as the local container registry is created on
+first boot. The boot is finished once the `registry` container is up and running.
+Verify with `docker ps`:
+
+```console
+dragon@metalbox:~$ docker ps
+CONTAINER ID   IMAGE        COMMAND                  CREATED          STATUS          PORTS                    NAMES
+2ff7d1d57b06   registry:3   "/entrypoint.sh /etc…"   44 seconds ago   Up 43 seconds   0.0.0.0:5001->5000/tcp   registry
+```
+
+:::
+
+### Deployment of the services
+
+Continue as the `dragon` user on the MetalBox.
+
+1. Import the NetBox files.
+   * Use the `netbox-export.img` file as virtual media (vHDD) and run
+     `netbox-import.sh` to import the NetBox files. Afterwards remove the virtual
+     media (vHDD).
+   * **or** Copy the `netbox-export.img` file to `/home/dragon` and run
+     `mount-images.sh`. Run `netbox-import.sh` to import the NetBox files. Afterwards
+     run `unmount-images.sh`.
+2. Run `deploy-netbox.sh` to deploy the NetBox service.
+3. Run `netbox-manage.sh` to initialise the NetBox service. Note that this can take a
+   couple of minutes to complete depending on the size of the installation.
+4. Run `get-netbox-config.sh NODE` to get the specific configuration for this MetalBox
+   from NetBox. Replace `NODE` with the name of the MetalBox device in NetBox.
+5. Run `deploy-manager.sh` to deploy the OSISM Manager service.
+6. Run `osism sync inventory` to sync the inventory.
+7. Run `osism apply hosts` to sync the `/etc/hosts` file.
+8. Run `osism apply network` to sync the network configuration.
+9. Run `osism apply frr` to sync the FRR configuration.
+10. Run `osism apply facts` to sync the facts.
+11. Run `osism apply chrony` to sync the NTP configuration.
+12. Decide whether the MetalBox is used as an Ubuntu repository server.
+    * If the MetalBox is to be used as an Ubuntu repository server for nodes inside
+      the CloudPod, do all steps in
+      [Using the MetalBox as an Ubuntu repository server](#ubuntu-repository-server).
+    * **or** Disable the use of the MetalBox as a repository server by running
+      `disable-repository.sh`.
+13. Decide whether the MetalBox is used as a SONiC ZTP server.
+    * If the MetalBox is to be used as a SONiC ZTP server, import the SONiC files:
+      * Use the file `sonic-export.img` as virtual media (vHDD) and run
+        `deploy-sonic.sh` to deploy the SONiC ZTP services. Afterwards remove the
+        virtual media (vHDD).
+      * **or** Copy the `sonic-export.img` file to `/home/dragon` and run
+        `mount-images.sh`. Run `deploy-sonic.sh` to deploy the SONiC ZTP services.
+        Afterwards run `unmount-images.sh`.
+    * **or** Disable the use of SONiC by running `disable-sonic.sh`.
+14. Run `deploy-infrastructure.sh` to deploy the infrastructure services.
+15. Run `deploy-openstack.sh` to deploy the OpenStack services.
+16. Upload the Ironic image files to `/opt/httpd/data/root`.
+17. Run `osism sync ironic` to sync the bare-metal nodes.
+18. Additional steps for air-gapped environments:
+    * If the MetalBox is to be used as a container registry for nodes inside the
+      CloudPod, do all steps in
+      [Using the MetalBox as a full container registry](#full-container-registry).
+    * If the MetalBox is to be used as a file server for nodes inside the CloudPod, do
+      all steps in [Using the MetalBox as a file server](#file-server).
+
+### Automated deployment with run-all.sh
+
+Instead of running the deployment steps individually, `run-all.sh` runs the sequence
+unattended. It takes the name of the managed site in NetBox as its argument, which it
+writes into the Manager configuration with `netbox-site.sh`:
+
+```bash
+run-all.sh SITE
+```
+
+The SONiC deployment steps can be skipped by setting `ENABLE_SONIC=false`. By
+default, SONiC is enabled.
+
+```bash
+ENABLE_SONIC=false run-all.sh SITE
+```
+
+:::note
+
+`run-all.sh` does not cover the full sequence above. `osism apply frr`, `osism apply
+chrony`, the decision about the Ubuntu repository server, and the upload of the Ironic
+image files to `/opt/httpd/data/root` are not part of it and still have to be carried
+out where they apply.
+
+:::
+
+## Option 2: Installation on an existing server or VM {#option-2-existing-server}
+
+This option deploys the MetalBox services on an existing machine instead of using the
+preconfigured MetalBox image. The machine can be a physical server or a virtual
+machine.
+
+### Prerequisites
+
+The server needs to be running Ubuntu 24.04 LTS. We recommend having at least 8
+vCPUs, 32 GB RAM and 100 GB SSD disk.
+
+### Basic preparation
+
+Execute these commands as a user on the server that has `sudo` access at least via a
+password. In the command example below this user is named `osism`, amend the commands
+accordingly if a different username is used.
+
+```bash
+cd
+sudo apt update
+sudo apt full-upgrade -y
+sudo apt install -y git pipx python3-venv sshpass
+git clone https://github.com/osism/metalbox/
+sudo mv metalbox /opt/configuration
+cd /opt/configuration/environments/manager/
+echo "ansible_connection: local" >> host_vars/metalbox/vars.yml
+./run.sh operator
+sudo chown -R dragon:dragon /opt/configuration
+```
+
+:::warning
+
+The `./run.sh operator` playbook invocation creates the `dragon` user and allows SSH
+login for it with a well-known SSH key that is contained in the metalbox repository.
+If the machine is reachable from the Internet via SSH, replace that key with a
+locally-generated secure SSH key.
+
+:::
+
+### Log in again as dragon
+
+The previous steps created the `dragon` user account which will be used to run the
+MetalBox services. Log in as that user either directly or by executing
+`sudo -iu dragon` from the existing account.
+
+### Prepare the MetalBox installation
+
+Prepare the environment:
+
+```bash
+cd
+git clone https://github.com/osism/openstack-ironic-images
+cd /opt/configuration/environments/manager/
+# Install ansible roles
+./run.sh noop
+# Run the metalbox preparation playbook
+venv/bin/ansible-playbook ~/openstack-ironic-images/elements/metalbox/static/root/part1.yml
+# Install some more python libs and another ansible collection
+pipx install netbox-manager
+pipx install 'ansible-core>=2.19.0,<2.20.0'
+/home/dragon/.local/bin/ansible-galaxy collection install netbox.netbox
+```
+
+The MetalBox installation runs a set of Docker containers from a local registry. Fill
+the registry volume with the container images and start the registry:
+
+```bash
+cd
+wget -O registry.tar.bz2 https://nbg1.your-objectstorage.com/osism/metalbox/registry.tar.bz2
+docker run --rm -v registry:/volume -v /home/dragon:/import library/alpine:3 sh -c 'cd /volume && tar xjf /import/registry.tar.bz2'
+docker run -d -p 0.0.0.0:5001:5000 -v registry:/var/lib/registry --name registry --restart always library/registry:3
+```
+
+Add a well-known IP address in order for some API operations to work. Depending on how
+the network is configured, it may make sense to add this configuration to the
+permanent configuration, e.g. by adding it to a file in `/etc/netplan`.
+
+```bash
+sudo ip link add metalbox type dummy
+sudo ip addr add 192.168.42.10/32 dev metalbox
+sudo ip link set up metalbox
+```
+
+### Fill the NetBox directory
+
+In the directory containing the NetBox data — this can be either a dedicated Git
+repository or the `netbox` subdirectory of the CloudPod repository — run:
+
+```bash
+netbox-manager export-archive
+netbox-manager import-archive
+```
+
+This copies the relevant data into `/opt/configuration/netbox/`.
+
+Deploy NetBox and fill it with data. Each of the following commands can take a couple
+of minutes to complete.
+
+```bash
+deploy-netbox.sh
+netbox-manage.sh
+```
+
+Run `get-netbox-config.sh NODE` to get the specific configuration for this MetalBox
+from NetBox. Replace `NODE` with the name of the MetalBox device in NetBox.
+
+### Finish the MetalBox installation
+
+Deploy the Manager and import the inventory from NetBox:
+
+```bash
+deploy-manager.sh
+osism sync inventory
+```
+
+:::note
+
+`deploy-manager.sh` refuses to run as long as the default site name `Discworld` is
+still configured in `/opt/configuration/environments/manager/configuration.yml`. Set
+the actual site name with `netbox-site.sh <your_site_name>` first.
+
+:::
+
+To deploy Ironic and the services it depends on, continue with the infrastructure and
+OpenStack services as in
+[Option 1, steps 12 to 17](#deployment-of-the-services): decide about the Ubuntu
+repository server and the SONiC ZTP server, then run `deploy-infrastructure.sh` and
+`deploy-openstack.sh`, upload the Ironic image files to `/opt/httpd/data/root`, and run
+`osism sync ironic`.
+
+Further tasks can then be performed on the MetalBox as documented in the rest of the
+documentation, e.g. managing Ironic nodes or SONiC switches.
+
+## Additional steps for air-gapped environments
+
+### Using the MetalBox as an Ubuntu repository server {#ubuntu-repository-server}
+
+1. Download the Ubuntu repository archive
+   [ubuntu-noble.tar.bz2](https://nbg1.your-objectstorage.com/osism/metalbox/ubuntu-noble.tar.bz2).
+2. Copy `ubuntu-noble.tar.bz2` to `/home/dragon` on the MetalBox node.
+3. Run `SKIP_DOWNLOAD=true update-repository.sh` to import the Ubuntu repository
+   files. Note that this can take a couple of minutes to finish.
+
+### Using the MetalBox as a full container registry {#full-container-registry}
+
+1. Download
+   [registry-2025.1-full.tar.bz2](https://nbg1.your-objectstorage.com/osism/metalbox/registry-2025.1-full.tar.bz2)
+   or, to use the pinned variant,
+   [registry-stable-full.tar.bz2](https://nbg1.your-objectstorage.com/osism/metalbox/registry-stable-full.tar.bz2).
+2. Rename the downloaded file to `registry.tar.bz2`.
+3. Copy `registry.tar.bz2` to `/home/dragon` on the MetalBox node.
+4. Run `SKIP_DOWNLOAD=true update-registry.sh` to update the container registry. Note
+   that this can take a couple of minutes to finish.
+
+### Using the MetalBox as a file server {#file-server}
+
+1. Download the Octavia image export
+   [octavia-export-2025.1.img](https://nbg1.your-objectstorage.com/osism/metalbox/octavia-export-2025.1.img).
+2. Copy `octavia-export-2025.1.img` to `/home/dragon` on the MetalBox node.
+3. Run `mount-images.sh` to mount the `octavia-export-2025.1.img` image.
+4. Run `octavia-import.sh` to import the Octavia image files.
+5. Run `unmount-images.sh` to unmount the `octavia-export-2025.1.img` image.
+
+## Appendix
+
+### Writing the MetalBox image directly to disk without unpacking
+
+To avoid the intermediate `osism-metalbox-image.raw` file, `funzip` can stream the
+contents of `osism-metalbox-image.zip` straight to the target disk. Export the target
+device as an environment variable first so the command does not accidentally reference
+the wrong disk. Verify the target with `lsblk` before running the command — the write
+is destructive.
+
+```bash
+DEVICE=/dev/sda
+funzip osism-metalbox-image.zip | dd of=$DEVICE bs=4M status=progress
+```
+
+## Next steps
+
+* [Data updates on the MetalBox](../upgrade-guide/metalbox/data-updates.md) —
+  update the NetBox data, the Ironic images, the container registry, and the Ubuntu
+  repository files.
+* [Service updates on the MetalBox](../upgrade-guide/metalbox/service-updates.md) —
+  update the Manager, NetBox, the infrastructure services, and the OpenStack services.
+* [Software RAID](../configuration-guide/metalbox/software-raid.md) — configure a
+  software RAID for the bare-metal nodes that are provisioned by the MetalBox.

--- a/docs/guides/deploy-guide/metalbox.md
+++ b/docs/guides/deploy-guide/metalbox.md
@@ -34,23 +34,29 @@ There are two ways to install a MetalBox:
 * Enough **local storage** for the container registry, the Ubuntu repository, and the
   Ironic images if the environment is air-gapped.
 
-All scripts referenced on this page are part of the MetalBox configuration repository.
-They are located in `/opt/configuration/scripts` and are available on the `PATH` of
-the `dragon` user, so they can be called by their plain name.
+All scripts referenced on this page come from the
+[metalbox repository](https://github.com/osism/metalbox), which is checked out to
+`/opt/configuration` on the MetalBox — already contained in the machine image in
+[Option 1](#option-1-metalbox-image), cloned manually in
+[Option 2](#option-2-existing-server). They are therefore located in
+`/opt/configuration/scripts` and are available on the `PATH` of the `dragon` user, so
+they can be called by their plain name.
 
 ## Release variants {#release-variants}
 
-For the container registry two variants are available:
+For the [container registry](../../concepts/metalbox.md#docker-registry) — the mirror
+that serves all container images to the MetalBox and to the nodes of the CloudPod —
+two variants are available:
 
 * **2025.1** — a rolling build of the current `2025.1` release. The images are rebuilt
   and republished regularly, so the tags inside `registry-2025.1-full.tar.bz2` move
   forward over time.
-* **stable** — always points to the current stable OSISM release (currently OSISM
-  `10.0.0` on kolla `2025.1`; future releases such as `10.1.0` will be published under
-  the same `stable` name). The image versions inside `registry-stable-full.tar.bz2`
-  are pinned per release and only change when a new stable OSISM release is published.
-  Use this variant for reproducible deployments that should not track the rolling
-  `2025.1` build.
+* **stable** — always points to the current stable OSISM release. The `stable` name
+  itself does not change as new releases are published; which release it currently
+  resolves to is listed in the [Release Notes](../../release-notes/index.md). The
+  image versions inside `registry-stable-full.tar.bz2` are pinned per release and only
+  change when a new stable OSISM release is published. Use this variant for
+  reproducible deployments that should not track the rolling `2025.1` build.
 
 The following sections default to the `2025.1` artifacts. Replace the file name with
 the `stable` counterpart (e.g. `registry-stable-full.tar.bz2` instead of
@@ -92,9 +98,11 @@ pod.
    `osism-metalbox-image.raw`.
 2. Download the latest small [Grml](https://grml.org/download/) live ISO file. When
    creating this document, the file name was `grml-small-2025.05-amd64.iso`.
-3. If SONiC is to be used: Download the SONiC export image `sonic-export.img` from the
-   well known URL. This file can also be created locally by running `sonic-export.sh`
-   inside a directory containing the SONiC images.
+3. If SONiC is to be used: Download the SONiC image for the switches from the vendor
+   that provides it. Place the `.bin` files in a directory and run `sonic-export.sh`
+   in that directory to pack them into the `sonic-export.img` file that is imported on
+   the MetalBox. By default the script picks up files matching
+   `sonic-broadcom-enterprise-base*.bin`; set `SONIC_PATTERN` for other file names.
 4. Export the NetBox configuration repository with
    `netbox-manager export-archive -i`. When using a NetBox configuration repository
    provided by OSISM, the file `netbox-export.img` can be downloaded from GitHub after
@@ -130,6 +138,11 @@ Downloads from the Hetzner Object Storage can occasionally be interrupted. Use
 
 ### Writing the image to disk
 
+All steps in this section are carried out through the BMC of the server over the
+out-of-band (OOB) management network: the files are attached as virtual media, the
+Grml live system is operated from the remote console, and the node is power-cycled
+through the BMC as well.
+
 1. Use the `osism-metalbox-image.raw` file as virtual media (vHDD).
 2. Use the `grml-small-2025.05-amd64.iso` file as virtual media (vDVD) and boot it.
 3. Write the MetalBox image to the first disk. Note that the exact names of the disks
@@ -141,6 +154,21 @@ Downloads from the Hetzner Object Storage can occasionally be interrupted. Use
 
    Afterwards power off the node, remove all virtual media devices and power on the
    node again.
+
+Log in on the remote console as the operator user `dragon` with the default password
+`password`. At this point the network of the MetalBox is not configured yet — that
+happens later with `osism apply network` — so the remote console is the only way in.
+
+:::warning
+
+Both the default password and the shipped SSH key are public. They are built into the
+MetalBox image through the `operator_password` and `operator_authorized_keys`
+variables in
+[`elements/metalbox/static/root/part1.yml`](https://github.com/osism/openstack-ironic-images/blob/main/elements/metalbox/static/root/part1.yml)
+of the openstack-ironic-images repository. Change the password of the `dragon` user
+and replace the SSH key before the MetalBox is reachable from anywhere untrusted.
+
+:::
 
 :::note
 
@@ -158,20 +186,25 @@ CONTAINER ID   IMAGE        COMMAND                  CREATED          STATUS    
 
 ### Deployment of the services
 
-Continue as the `dragon` user on the MetalBox.
+Continue as the `dragon` user on the MetalBox (default credentials `dragon` /
+`password`).
 
 1. Import the NetBox files.
    * Use the `netbox-export.img` file as virtual media (vHDD) and run
      `netbox-import.sh` to import the NetBox files. Afterwards remove the virtual
      media (vHDD).
-   * **or** Copy the `netbox-export.img` file to `/home/dragon` and run
-     `mount-images.sh`. Run `netbox-import.sh` to import the NetBox files. Afterwards
-     run `unmount-images.sh`.
+   * **or** Make the `netbox-export.img` file available in `/home/dragon` — the
+     network is not configured at this point, so it has to come from local media such
+     as a USB stick or another disk that is not touched during the deployment — and
+     run `mount-images.sh`. Run `netbox-import.sh` to import the NetBox files.
+     Afterwards run `unmount-images.sh`.
 2. Run `deploy-netbox.sh` to deploy the NetBox service.
 3. Run `netbox-manage.sh` to initialise the NetBox service. Note that this can take a
    couple of minutes to complete depending on the size of the installation.
 4. Run `get-netbox-config.sh NODE` to get the specific configuration for this MetalBox
-   from NetBox. Replace `NODE` with the name of the MetalBox device in NetBox.
+   from NetBox. Replace `NODE` with the name of the MetalBox device in NetBox. This
+   also sets the site that the MetalBox manages, taken from the site the device is
+   assigned to.
 5. Run `deploy-manager.sh` to deploy the OSISM Manager service.
 6. Run `osism sync inventory` to sync the inventory.
 7. Run `osism apply hosts` to sync the `/etc/hosts` file.
@@ -196,7 +229,8 @@ Continue as the `dragon` user on the MetalBox.
     * **or** Disable the use of SONiC by running `disable-sonic.sh`.
 14. Run `deploy-infrastructure.sh` to deploy the infrastructure services.
 15. Run `deploy-openstack.sh` to deploy the OpenStack services.
-16. Upload the Ironic image files to `/opt/httpd/data/root`.
+16. Upload the Ironic image files downloaded in [Preparation](#preparation) to
+    `/opt/httpd/data/root`.
 17. Run `osism sync ironic` to sync the bare-metal nodes.
 18. Additional steps for air-gapped environments:
     * If the MetalBox is to be used as a container registry for nodes inside the
@@ -204,32 +238,6 @@ Continue as the `dragon` user on the MetalBox.
       [Using the MetalBox as a full container registry](#full-container-registry).
     * If the MetalBox is to be used as a file server for nodes inside the CloudPod, do
       all steps in [Using the MetalBox as a file server](#file-server).
-
-### Automated deployment with run-all.sh
-
-Instead of running the deployment steps individually, `run-all.sh` runs the sequence
-unattended. It takes the name of the managed site in NetBox as its argument, which it
-writes into the Manager configuration with `netbox-site.sh`:
-
-```bash
-run-all.sh SITE
-```
-
-The SONiC deployment steps can be skipped by setting `ENABLE_SONIC=false`. By
-default, SONiC is enabled.
-
-```bash
-ENABLE_SONIC=false run-all.sh SITE
-```
-
-:::note
-
-`run-all.sh` does not cover the full sequence above. `osism apply frr`, `osism apply
-chrony`, the decision about the Ubuntu repository server, and the upload of the Ironic
-image files to `/opt/httpd/data/root` are not part of it and still have to be carried
-out where they apply.
-
-:::
 
 ## Option 2: Installation on an existing server or VM {#option-2-existing-server}
 
@@ -244,9 +252,7 @@ vCPUs, 32 GB RAM and 100 GB SSD disk.
 
 ### Basic preparation
 
-Execute these commands as a user on the server that has `sudo` access at least via a
-password. In the command example below this user is named `osism`, amend the commands
-accordingly if a different username is used.
+Execute these commands as any user on the server that has `sudo` access.
 
 ```bash
 cd
@@ -263,18 +269,26 @@ sudo chown -R dragon:dragon /opt/configuration
 
 :::warning
 
-The `./run.sh operator` playbook invocation creates the `dragon` user and allows SSH
-login for it with a well-known SSH key that is contained in the metalbox repository.
-If the machine is reachable from the Internet via SSH, replace that key with a
-locally-generated secure SSH key.
+The `./run.sh operator` playbook invocation creates the `dragon` user and installs a
+public SSH key for it — the same key the MetalBox image ships. It comes from the
+`operator_authorized_keys` variable in
+[`environments/configuration.yml`](https://github.com/osism/metalbox/blob/main/environments/configuration.yml)
+of the metalbox repository. Replace the key with a locally generated one before the
+machine is reachable from anywhere untrusted. No password is set for the `dragon` user
+in this variant; the account is created with a locked password.
 
 :::
 
 ### Log in again as dragon
 
 The previous steps created the `dragon` user account which will be used to run the
-MetalBox services. Log in as that user either directly or by executing
-`sudo -iu dragon` from the existing account.
+MetalBox services. Switch to it in one of two ways:
+
+* Run `sudo -iu dragon` from the account used so far.
+* Log in over SSH with the private key that matches the installed public key. It is
+  published as `operator_private_key` in
+  [`elements/metalbox/static/root/part1.yml`](https://github.com/osism/openstack-ironic-images/blob/main/elements/metalbox/static/root/part1.yml)
+  of the openstack-ironic-images repository.
 
 ### Prepare the MetalBox installation
 
@@ -304,15 +318,29 @@ docker run --rm -v registry:/volume -v /home/dragon:/import library/alpine:3 sh 
 docker run -d -p 0.0.0.0:5001:5000 -v registry:/var/lib/registry --name registry --restart always library/registry:3
 ```
 
-Add a well-known IP address in order for some API operations to work. Depending on how
-the network is configured, it may make sense to add this configuration to the
-permanent configuration, e.g. by adding it to a file in `/etc/netplan`.
+Add the internal address of the MetalBox. The configuration is pinned to the fixed
+address `192.168.42.10` on a dummy interface named `metalbox`, and several components
+expect to find it there:
+
+* it is the `kolla_internal_vip_address` under which Keystone and Ironic are reached,
+* it is the endpoint of the NetBox API (`http://192.168.42.10:8121`), which
+  `get-netbox-config.sh` and the Manager query,
+* it is the `ansible_host` of the MetalBox in its own inventory, so the Manager
+  reaches the node it runs on through it,
+* and it is what the `metalbox.osism.xyz` and `api.metalbox.osism.xyz` host entries
+  resolve to.
 
 ```bash
 sudo ip link add metalbox type dummy
 sudo ip addr add 192.168.42.10/32 dev metalbox
 sudo ip link set up metalbox
 ```
+
+On the MetalBox image this interface is created by `osism apply network` from the
+`network_dummy_devices` variable. On an existing server it is set up by hand as shown
+above, and because a dummy interface does not survive a reboot, it should also be
+added to the permanent network configuration, for example in a file in
+`/etc/netplan`.
 
 ### Fill the NetBox directory
 
@@ -335,7 +363,9 @@ netbox-manage.sh
 ```
 
 Run `get-netbox-config.sh NODE` to get the specific configuration for this MetalBox
-from NetBox. Replace `NODE` with the name of the MetalBox device in NetBox.
+from NetBox. Replace `NODE` with the name of the MetalBox device in NetBox. This also
+sets the site that the MetalBox manages, taken from the site the device is assigned
+to.
 
 ### Finish the MetalBox installation
 
@@ -346,20 +376,25 @@ deploy-manager.sh
 osism sync inventory
 ```
 
-:::note
+Ironic and the services it depends on are not deployed yet. Continue with the
+remaining steps of [Option 1](#deployment-of-the-services):
 
-`deploy-manager.sh` refuses to run as long as the default site name `Discworld` is
-still configured in `/opt/configuration/environments/manager/configuration.yml`. Set
-the actual site name with `netbox-site.sh <your_site_name>` first.
+1. Run `osism apply hosts` to sync the `/etc/hosts` file. The OpenStack services are
+   reached under `api.metalbox.osism.xyz` and `metalbox.osism.xyz`, which resolve
+   through these entries.
+2. Run `osism apply facts` to sync the facts.
+3. Run `osism apply chrony` to sync the NTP configuration.
+4. Decide whether the MetalBox is used as an Ubuntu repository server and as a SONiC
+   ZTP server, as in steps 12 and 13 of Option 1.
+5. Run `deploy-infrastructure.sh` to deploy the infrastructure services.
+6. Run `deploy-openstack.sh` to deploy the OpenStack services.
+7. Upload the Ironic image files listed in [Preparation](#preparation) to
+   `/opt/httpd/data/root`.
+8. Run `osism sync ironic` to sync the bare-metal nodes.
 
-:::
-
-To deploy Ironic and the services it depends on, continue with the infrastructure and
-OpenStack services as in
-[Option 1, steps 12 to 17](#deployment-of-the-services): decide about the Ubuntu
-repository server and the SONiC ZTP server, then run `deploy-infrastructure.sh` and
-`deploy-openstack.sh`, upload the Ironic image files to `/opt/httpd/data/root`, and run
-`osism sync ironic`.
+`osism apply network` and `osism apply frr` are not part of this variant. The network
+of an existing server is managed outside the MetalBox, which is why the dummy
+interface above is created by hand.
 
 Further tasks can then be performed on the MetalBox as documented in the rest of the
 documentation, e.g. managing Ironic nodes or SONiC switches.
@@ -380,10 +415,14 @@ documentation, e.g. managing Ironic nodes or SONiC switches.
    [registry-2025.1-full.tar.bz2](https://nbg1.your-objectstorage.com/osism/metalbox/registry-2025.1-full.tar.bz2)
    or, to use the pinned variant,
    [registry-stable-full.tar.bz2](https://nbg1.your-objectstorage.com/osism/metalbox/registry-stable-full.tar.bz2).
-2. Rename the downloaded file to `registry.tar.bz2`.
-3. Copy `registry.tar.bz2` to `/home/dragon` on the MetalBox node.
-4. Run `SKIP_DOWNLOAD=true update-registry.sh` to update the container registry. Note
-   that this can take a couple of minutes to finish.
+2. Copy the file to `/home/dragon` on the MetalBox node.
+3. Import it with `REGISTRY_FILE` set to its name — it defaults to `registry.tar.bz2`,
+   so it has to be set for any other name. Note that this can take a couple of minutes
+   to finish.
+
+   ```bash
+   SKIP_DOWNLOAD=true REGISTRY_FILE=registry-2025.1-full.tar.bz2 update-registry.sh
+   ```
 
 ### Using the MetalBox as a file server {#file-server}
 

--- a/docs/guides/troubleshooting-guide/metalbox.md
+++ b/docs/guides/troubleshooting-guide/metalbox.md
@@ -1,0 +1,42 @@
+---
+sidebar_label: MetalBox
+---
+
+# MetalBox
+
+## Inspecting images on the local container registry
+
+If something does not work as expected with container images served from the local
+registry — e.g. a deployment pulls the wrong tag, an image is reported as missing, or
+after an `update-registry.sh` or `single-image-import.sh` run it is unclear whether a
+specific image actually ended up in the mirror — use `list-registry-images.sh` to
+enumerate what is currently stored on the local registry (`localhost:5001`).
+
+```bash
+list-registry-images.sh          # list all repositories with their tags
+list-registry-images.sh -t       # list only repository names
+list-registry-images.sh -d       # list tags including the content digest
+list-registry-images.sh -h       # show full help
+```
+
+## Manual preparation of the Ironic volume
+
+```bash
+docker run --rm --name httpd-ironic \
+  --entrypoint /prepare-ironic-volume.sh \
+  -v /opt/httpd/configuration/prepare-ironic-volume.sh:/prepare-ironic-volume.sh \
+  -v ironic:/var/lib/ironic \
+  localhost:5001/library/httpd:alpine
+```
+
+## Resumable downloads with aria2c {#resumable-downloads-with-aria2c}
+
+Downloads from the Hetzner Object Storage can occasionally be interrupted. Use `aria2c`
+for resumable, multi-connection downloads:
+
+```bash
+aria2c -x 4 -s 4 --auto-file-renaming=false https://nbg1.your-objectstorage.com/osism/metalbox/ubuntu-noble.tar.bz2
+```
+
+Replace the URL as needed for other files. The `-x 4 -s 4` flags use 4 connections for
+faster downloads, and `--auto-file-renaming=false` prevents duplicate files on resume.

--- a/docs/guides/troubleshooting-guide/metalbox.md
+++ b/docs/guides/troubleshooting-guide/metalbox.md
@@ -21,6 +21,24 @@ list-registry-images.sh -h       # show full help
 
 ## Manual preparation of the Ironic volume
 
+The `ironic` Docker volume is shared between Ironic and the HTTPd. Ironic writes the
+boot artifacts for the nodes into `/var/lib/ironic/httpboot`, and the HTTPd publishes
+that directory as `/ironic` — the path the nodes fetch from through
+`external_http_url`. For this to work, the directory has to exist and belong to
+uid/gid `42422`, the `ironic` user inside the containers.
+
+Preparing the volume is part of `osism apply httpd`, which normally runs through
+[`deploy-infrastructure.sh`](https://github.com/osism/metalbox/blob/main/scripts/deploy-infrastructure.sh#L15)
+during the deployment. Use `osism apply httpd` whenever it is available — it covers the
+volume and the rest of the HTTPd configuration. Note that `deploy-infrastructure.sh`
+only calls it when the `httpd` container is not already running, so re-running that
+script does not repair an emptied volume on a MetalBox whose HTTPd is up.
+
+The command below is the fallback for when the play cannot run at all: `osism apply`
+dispatches through the Manager and its task queue, so it is unavailable before the
+Manager and the infrastructure services are deployed, and while they are broken. The
+manual invocation only needs Docker and the local registry:
+
 ```bash
 docker run --rm --name httpd-ironic \
   --entrypoint /prepare-ironic-volume.sh \
@@ -28,6 +46,9 @@ docker run --rm --name httpd-ironic \
   -v ironic:/var/lib/ironic \
   localhost:5001/library/httpd:alpine
 ```
+
+The script only does something when `/var/lib/ironic/httpboot` does not exist, so
+running it against an already prepared volume changes nothing.
 
 ## Resumable downloads with aria2c {#resumable-downloads-with-aria2c}
 

--- a/docs/guides/upgrade-guide/baremetal/index.md
+++ b/docs/guides/upgrade-guide/baremetal/index.md
@@ -1,5 +1,0 @@
----
-sidebar_label: Baremetal
----
-
-# Baremetal

--- a/docs/guides/upgrade-guide/metalbox/data-updates.md
+++ b/docs/guides/upgrade-guide/metalbox/data-updates.md
@@ -1,0 +1,131 @@
+---
+sidebar_label: Data updates
+sidebar_position: 10
+---
+
+# Data updates on the MetalBox
+
+The data a MetalBox serves — the NetBox inventory, the Ironic images, the container
+images, and the Ubuntu packages — is updated independently of the MetalBox services
+themselves. The update of the services is described in
+[Service updates](./service-updates.md).
+
+Most of the updates can be performed either with or without external connectivity. In
+the variant without external connectivity, the artifacts are downloaded elsewhere,
+copied to `/home/dragon` on the MetalBox node, and the update script is run with
+`SKIP_DOWNLOAD=true` so that it uses the local file instead of fetching it.
+
+:::tip
+
+Downloads from the Hetzner Object Storage can occasionally be interrupted. Use
+`aria2c` for resumable, multi-connection downloads as described in the
+[Troubleshooting Guide](../../troubleshooting-guide/metalbox.md#resumable-downloads-with-aria2c).
+
+:::
+
+## Update of the NetBox data
+
+1. Export the NetBox configuration repository with
+   `netbox-manager export-archive -i`. When using a NetBox configuration repository
+   provided by OSISM, the file can be downloaded from GitHub after a trigger of the
+   `Run export` action. Copy `netbox-export.img` to `/home/dragon` on the MetalBox
+   node.
+2. Run `mount-images.sh` to mount the `netbox-export.img` image.
+3. Run `netbox-import.sh` to sync the files in `/opt/configuration/netbox`.
+4. Run `unmount-images.sh` to unmount the `netbox-export.img` image.
+5. Run `netbox-manage.sh` to sync NetBox with the state in
+   `/opt/configuration/netbox`.
+
+It is also possible to update only the data of specific devices. To do this, the
+netbox-manager can be used directly in the NetBox directory. In the following example,
+only files with the prefix `300-node10` are processed.
+
+```bash
+cd /opt/configuration/netbox
+netbox-manager run --limit 300-node10
+```
+
+## Update of the Ironic images
+
+### Without external connectivity
+
+1. Download the Ironic images:
+   * [osism-ipa.initramfs](https://nbg1.your-objectstorage.com/osism/openstack-ironic-images/osism-ipa.initramfs)
+   * [osism-ipa.kernel](https://nbg1.your-objectstorage.com/osism/openstack-ironic-images/osism-ipa.kernel)
+   * [osism-node.qcow2](https://nbg1.your-objectstorage.com/osism/openstack-ironic-images/osism-node.qcow2)
+   * [osism-node.qcow2.CHECKSUM](https://nbg1.your-objectstorage.com/osism/openstack-ironic-images/osism-node.qcow2.CHECKSUM)
+   * [osism-esp.raw](https://nbg1.your-objectstorage.com/osism/openstack-ironic-images/osism-esp.raw)
+2. Copy the downloaded files to `/home/dragon` on the MetalBox node.
+3. Run `SKIP_DOWNLOAD=true update-ironic-images.sh` to update the Ironic images.
+
+### With external connectivity
+
+1. Run `update-ironic-images.sh` to update the Ironic images.
+
+## Update of the container registry
+
+### Without external connectivity
+
+1. Download
+   [registry.tar.bz2](https://nbg1.your-objectstorage.com/osism/metalbox/registry.tar.bz2).
+2. Copy `registry.tar.bz2` to `/home/dragon` on the MetalBox node.
+3. Run `SKIP_DOWNLOAD=true update-registry.sh` to update the container registry.
+
+### With external connectivity
+
+1. Run `update-registry.sh` to update the container registry.
+
+:::info
+
+`registry.tar.bz2` is the version-independent base tarball for the MetalBox itself. To
+serve all container images required by the nodes inside the CloudPod, one of the full
+variants is needed instead. The available tarballs are described in
+[Container registry tarballs](../../deploy-guide/metalbox.md#container-registry-tarballs),
+the import procedure in
+[Using the MetalBox as a full container registry](../../deploy-guide/metalbox.md#full-container-registry).
+
+:::
+
+### Update from a single image on the container registry
+
+Instead of updating the whole registry, a single image can be exported on a local
+system and imported on the MetalBox. Replace `osism/inventory-reconciler:latest` and
+`registry-delta-YYYYMMDD-HHMM.tar.gz` as needed.
+
+1. Run `scripts/single-image-export.sh osism/inventory-reconciler:latest` on a local
+   system to create a `registry-delta-YYYYMMDD-HHMM.tar.gz` file. A matching
+   `.CHECKSUM` file is written next to it.
+2. Copy `registry-delta-YYYYMMDD-HHMM.tar.gz` to `/home/dragon` on the MetalBox node.
+3. Run `single-image-import.sh registry-delta-YYYYMMDD-HHMM.tar.gz` on the MetalBox
+   node to import the image into the local registry on `localhost:5001`.
+
+The image passed to `single-image-export.sh` is given **without** the registry host but
+**with** its namespace prefix, which selects where the image is pulled from:
+
+* `osism/` — OSISM Manager images, e.g. `osism/ara-server:1.7.3`
+* `kolla/` — Kolla images, e.g. `kolla/nova-api:2024.2`
+* `dockerhub/` — Docker Hub images, e.g. `dockerhub/library/redis:7.4.7-alpine`
+
+The source registry defaults to `registry.osism.tech` and can be overridden with the
+`DOCKER_REGISTRY` environment variable. A `registry.osism.tech/` or
+`registry.osism.cloud/` prefix on the image is accepted and stripped, so
+`registry.osism.tech/osism/inventory-reconciler:latest` works as well. The
+`dockerhub/` prefix is removed for the destination name, so the image ends up in the
+registry under `library/redis:7.4.7-alpine`.
+
+`single-image-import.sh` reads the target image name from the `manifest.txt` inside the
+tarball and pushes to `localhost:5001` by default; the target can be overridden with
+the `TARGET_REGISTRY` environment variable. The registry must already be running.
+
+## Update of the Ubuntu repository files
+
+### Without external connectivity
+
+1. Download
+   [ubuntu-noble.tar.bz2](https://nbg1.your-objectstorage.com/osism/metalbox/ubuntu-noble.tar.bz2).
+2. Copy `ubuntu-noble.tar.bz2` to `/home/dragon` on the MetalBox node.
+3. Run `SKIP_DOWNLOAD=true update-repository.sh` to update the Ubuntu repository files.
+
+### With external connectivity
+
+1. Run `update-repository.sh` to update the Ubuntu repository.

--- a/docs/guides/upgrade-guide/metalbox/data-updates.md
+++ b/docs/guides/upgrade-guide/metalbox/data-updates.md
@@ -64,27 +64,53 @@ netbox-manager run --limit 300-node10
 
 ## Update of the container registry
 
+Which tarball is the right one depends on what the registry has to serve:
+
+* **`registry.tar.bz2`** — the version-independent base tarball. It contains the images
+  for the MetalBox services themselves and is enough when the nodes of the CloudPod
+  pull their images from somewhere else.
+* **a full variant** — `registry-2025.1-full.tar.bz2` or `registry-stable-full.tar.bz2`,
+  which additionally contain the OpenStack images the CloudPod nodes need. In
+  air-gapped environments this is almost always the one to use, because the nodes have
+  no other source. The variants are described in
+  [Container registry tarballs](../../deploy-guide/metalbox.md#container-registry-tarballs).
+
+:::warning
+
+`update-registry.sh` removes the registry volume and recreates it from the tarball, so
+an update replaces the entire content of the registry rather than adding to it.
+Updating a MetalBox that serves the CloudPod with the base `registry.tar.bz2` therefore
+drops the OpenStack images from it.
+
+:::
+
 ### Without external connectivity
 
-1. Download
-   [registry.tar.bz2](https://nbg1.your-objectstorage.com/osism/metalbox/registry.tar.bz2).
-2. Copy `registry.tar.bz2` to `/home/dragon` on the MetalBox node.
-3. Run `SKIP_DOWNLOAD=true update-registry.sh` to update the container registry.
+1. Download the tarball, for example
+   [registry-stable-full.tar.bz2](https://nbg1.your-objectstorage.com/osism/metalbox/registry-stable-full.tar.bz2).
+2. Copy it to `/home/dragon` on the MetalBox node.
+3. Run the update. `REGISTRY_FILE` names the file to import and defaults to
+   `registry.tar.bz2`, so it has to be set for any other name.
+
+   ```bash
+   SKIP_DOWNLOAD=true REGISTRY_FILE=registry-stable-full.tar.bz2 update-registry.sh
+   ```
 
 ### With external connectivity
 
-1. Run `update-registry.sh` to update the container registry.
+Run `update-registry.sh` to update the container registry. It downloads
+`registry.tar.bz2` on its own, nothing else has to be set.
 
-:::info
+```bash
+update-registry.sh
+```
 
-`registry.tar.bz2` is the version-independent base tarball for the MetalBox itself. To
-serve all container images required by the nodes inside the CloudPod, one of the full
-variants is needed instead. The available tarballs are described in
-[Container registry tarballs](../../deploy-guide/metalbox.md#container-registry-tarballs),
-the import procedure in
-[Using the MetalBox as a full container registry](../../deploy-guide/metalbox.md#full-container-registry).
+Setting `REGISTRY_URL` is optional and only needed to fetch a full variant instead of
+the base tarball.
 
-:::
+```bash
+REGISTRY_URL=https://nbg1.your-objectstorage.com/osism/metalbox/registry-stable-full.tar.bz2 update-registry.sh
+```
 
 ### Update from a single image on the container registry
 

--- a/docs/guides/upgrade-guide/metalbox/index.md
+++ b/docs/guides/upgrade-guide/metalbox/index.md
@@ -1,0 +1,21 @@
+---
+sidebar_label: MetalBox
+sidebar_key: upgrade-guide-metalbox
+---
+
+# MetalBox
+
+The following pages describe how a MetalBox is kept up to date.
+
+* [Data updates](./data-updates.md) — update the NetBox data, the Ironic images, the
+  container registry, and the Ubuntu repository files.
+* [Service updates](./service-updates.md) — update the Manager, NetBox, the
+  infrastructure services, and the OpenStack services.
+
+The installation of a MetalBox is described in the
+[Deploy Guide](../../deploy-guide/metalbox.md), its architecture in the
+[OSISM MetalBox](../../../concepts/metalbox.md) concept.
+
+All scripts referenced on these pages are located in `/opt/configuration/scripts` on
+the MetalBox and are available on the `PATH` of the `dragon` user, so they can be
+called by their plain name.

--- a/docs/guides/upgrade-guide/metalbox/service-updates.md
+++ b/docs/guides/upgrade-guide/metalbox/service-updates.md
@@ -1,0 +1,40 @@
+---
+sidebar_label: Service updates
+sidebar_position: 20
+---
+
+# Service updates on the MetalBox
+
+The services running on the MetalBox are updated by running the corresponding
+`update-*.sh` script.
+
+:::warning
+
+The MetalBox pulls all container images from its local registry. The container registry
+must therefore be updated first, otherwise the update scripts redeploy the services
+with the images that are already present. See
+[Update of the container registry](./data-updates.md#update-of-the-container-registry).
+
+:::
+
+## Update of the Manager service
+
+1. The container registry must be updated first in order to receive Manager updates.
+2. Run `update-manager.sh` to update the Manager service.
+
+## Update of the NetBox service
+
+1. The container registry must be updated first in order to receive a NetBox update.
+2. Run `update-netbox.sh` to update the NetBox service.
+
+## Update of the infrastructure services
+
+1. The container registry must be updated first in order to receive infrastructure
+   service updates.
+2. Run `update-infrastructure.sh` to update the infrastructure services.
+
+## Update of the OpenStack services
+
+1. The container registry must be updated first in order to receive OpenStack service
+   updates.
+2. Run `update-openstack.sh` to update the OpenStack services.

--- a/docs/guides/upgrade-guide/metalbox/service-updates.md
+++ b/docs/guides/upgrade-guide/metalbox/service-updates.md
@@ -19,22 +19,16 @@ with the images that are already present. See
 
 ## Update of the Manager service
 
-1. The container registry must be updated first in order to receive Manager updates.
-2. Run `update-manager.sh` to update the Manager service.
+Run `update-manager.sh` to update the Manager service.
 
 ## Update of the NetBox service
 
-1. The container registry must be updated first in order to receive a NetBox update.
-2. Run `update-netbox.sh` to update the NetBox service.
+Run `update-netbox.sh` to update the NetBox service.
 
 ## Update of the infrastructure services
 
-1. The container registry must be updated first in order to receive infrastructure
-   service updates.
-2. Run `update-infrastructure.sh` to update the infrastructure services.
+Run `update-infrastructure.sh` to update the infrastructure services.
 
 ## Update of the OpenStack services
 
-1. The container registry must be updated first in order to receive OpenStack service
-   updates.
-2. Run `update-openstack.sh` to update the OpenStack services.
+Run `update-openstack.sh` to update the OpenStack services.


### PR DESCRIPTION
Moves the MetalBox documentation out of the
[osism/metalbox](https://github.com/osism/metalbox) `README.md` (and
`INSTALL-VM.md`) into the documentation site, so that it is discoverable and the
[OSISM MetalBox](https://github.com/osism/osism.github.io/blob/main/docs/concepts/metalbox.md)
concept no longer has to link out to GitHub for every procedure.

The content is spread across the guide categories we already have rather than
getting a MetalBox section of its own, so each procedure sits in the guide that
covers its kind of task:

| Page | Imported content |
|:--|:--|
| `guides/deploy-guide/metalbox.md` | Deployment scenario, release variants, container registry tarballs, preparation and downloads, writing the image to disk, deployment of the services, air-gap procedures, direct-to-disk appendix — plus `INSTALL-VM.md` as a second installation option |
| `guides/upgrade-guide/metalbox/data-updates.md` | NetBox data, Ironic images, container registry (incl. single-image import), Ubuntu repository |
| `guides/upgrade-guide/metalbox/service-updates.md` | Manager, NetBox, infrastructure and OpenStack service updates |
| `guides/configuration-guide/metalbox/software-raid.md` | `target_raid_config` via the NetBox `ironic_parameters` custom field, `conductor.yml`, mdraid rebuild speed limits |
| `guides/troubleshooting-guide/metalbox.md` | Registry image inspection, manual Ironic volume preparation, resumable downloads with `aria2c` |

The MetalBox installation is placed at position 5 in the Deploy Guide, ahead of
the Seed step, since the MetalBox is installed before the CloudPod.

## Renamed categories

The empty `Baremetal` placeholders in the Configuration Guide and the Upgrade
Guide are renamed to `MetalBox`, so the category is named the same way in every
guide. Both were unreferenced five-line stubs.

Note for anyone hitting this later: two autogenerated sidebar **categories** with
the same label produce the same translation key and Docusaurus fails the build
for it. The old `Baremetal` folders never triggered it because a folder holding
only an `index.md` renders as a plain link rather than a category. Both category
indexes therefore carry a `sidebar_key`.

The still-empty `operations-guide/baremetal/` placeholder is left untouched.

## Deliberately more than the README says

The second commit reworks the imported text after a read-through. A number of
statements were carried over from the README that are vague, or true for only one
of the two installation variants, and some facts an operator needs were missing
altogether. Everything below was verified against `osism/metalbox` and
`osism/openstack-ironic-images` rather than inferred from the README:

- The scripts under `/opt/configuration` come from a checkout of the metalbox
  repository — baked in by the image build, cloned by hand in Option 2 — and are
  on the `PATH` of the `dragon` user.
- The image variant ships `dragon` / `password` and a public SSH key, both from
  `operator_password` / `operator_authorized_keys` in the image element's
  `part1.yml`, which also carries the matching private key. Option 2 sets **no**
  password: with `operator_password` unset, `osism.commons.operator` creates the
  account with a locked password.
- Until `osism apply network` runs, the MetalBox has no network. The remote
  console is the only way in, and the NetBox export has to arrive on local media
  rather than by copying it over.
- `get-netbox-config.sh` also sets the managed site, by calling `netbox-site.sh`
  with the site of the device.
- `192.168.42.10` on the `metalbox` dummy interface is the
  `kolla_internal_vip_address`, the NetBox API endpoint, the `ansible_host` of the
  MetalBox in its own inventory and the target of the `metalbox.osism.xyz` host
  entries. On the image it is created by `osism apply network`; Option 2 creates
  it by hand, which is why it also has to be persisted.
- Option 2 was missing `osism apply hosts`, `facts` and `chrony`. The host entries
  matter: `kolla_internal_fqdn` and the Ironic `external_http_url` address the
  services by name, and nothing else resolves those names.
- `update-registry.sh` removes and recreates the registry volume, so an update
  replaces the whole registry. Updating a MetalBox that serves the CloudPod with
  the base `registry.tar.bz2` drops the OpenStack images. The page now leads with
  the choice of tarball and uses `REGISTRY_FILE` / `REGISTRY_URL` instead of
  renaming the download.
- `single-image-export.sh` takes the image **without** the registry host but
  **with** the namespace prefix (`osism/`, `kolla/`, `dockerhub/`) that selects
  where it is pulled from.
- The manual preparation of the Ironic volume was a bare command. It now says what
  the volume is for, recommends `osism apply httpd` instead, and notes that
  `deploy-infrastructure.sh` only applies the role when the `httpd` container is not
  already running — so re-running it does not repair an emptied volume.

The `run-all.sh` section was dropped again: the script diverges from the
documented sequence, which is being handled in osism/metalbox#376 and
osism/metalbox#377.

## Verified

`yarn build` passes with `onBrokenLinks: 'throw'` and no broken-anchor warnings.
MegaLinter (documentation flavor, as in CI) is clean on all changed files —
markdownlint, markdown-table-formatter and codespell included.

## Follow-ups, not in this PR

- The `README.md` in osism/metalbox still carries this content and should be
  reduced to a pointer here.
- Documentation for using the MetalBox to deploy and redeploy servers.
- If a device has no site in NetBox, `get-netbox-config.sh` only warns and
  `deploy-manager.sh` later aborts on the default site name. Would fit the
  Troubleshooting Guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
