### PR TITLE
manager: document the update with run.sh

### DIFF
--- a/docs/guides/configuration-guide/manager.mdx
+++ b/docs/guides/configuration-guide/manager.mdx
@@ -130,8 +130,9 @@ manager_opensearch_port: 9200
 manager_opensearch_protocol: https
 ```
 
-The integration can also be enabled later. `osism update manager` is then
-executed after the configuration has been changed.
+The integration can also be enabled later. The manager service is then updated after
+the configuration has been changed, as described in the
+[Manager upgrade guide](../upgrade-guide/manager.mdx).
 
 ## OpenStack broker integration
 

--- a/docs/guides/upgrade-guide/manager.mdx
+++ b/docs/guides/upgrade-guide/manager.mdx
@@ -17,6 +17,18 @@ adjustments are necessary. Read the release notes even if you are only updating 
 The update of a manager service with a stable release of OSISM is described here.
 In the example, OSISM release 7.0.5 is used.
 
+:::info Where these steps run
+
+Steps 1 and 3 are run in a checkout of the configuration repository — the machine
+the cluster was deployed from, or the manager itself, where the repository is at
+`/opt/configuration`. Steps 2 and 4 to 6 use the `osism` command and are run on the
+manager.
+
+Step 1 pushes the change and step 2 pulls it onto the manager, so both checkouts
+are at the same commit by the time step 3 runs.
+
+:::
+
 1. Change the OSISM release in the configuration repository.
 
     1. Set the new OSISM version in the configuration repository.
@@ -78,16 +90,16 @@ In the example, OSISM release 7.0.5 is used.
     osism apply configuration
     ```
 
-3. Update the manager service. The `osism.manager.manager` playbook is driven against
-   the manager over SSH, so this can run on any machine that has a checkout of the
-   configuration repository and can reach the manager — the machine the cluster was
-   deployed from, or the manager itself, where the repository is at
-   `/opt/configuration`. Run it in the `environments/manager` directory.
+3. Update the manager service. Run this in the `environments/manager` directory of the
+   configuration repository.
 
     ```bash
     ./run.sh manager
     ```
 
+    * The `osism.manager.manager` playbook is driven against the manager over SSH, so it
+      does not matter which machine runs it, as long as that machine has a checkout of
+      the configuration repository and can reach the manager.
     * `run.sh` ships in the configuration repository and is refreshed by `make sync`
       (step 1), so it does not depend on the tooling installed on the machine that runs
       it. It also chooses how to execute the playbook by itself: with a container engine

--- a/docs/guides/upgrade-guide/manager.mdx
+++ b/docs/guides/upgrade-guide/manager.mdx
@@ -20,40 +20,25 @@ In the example, OSISM release 7.0.5 is used.
 :::info Which update path applies to you
 
 Step 3 below drives the `osism.manager.manager` playbook against the manager over
-SSH. The same playbook is used in every case; only how it is launched depends on
-how you deployed the cluster. Steps 1, 2 and 4 to 6 are the same for all of them.
+SSH, with the `run.sh` script from the configuration repository. The playbook and
+the script are the same in every case; only where you run them depends on how you
+deployed the cluster. Steps 1, 2 and 4 to 6 are the same for all of them.
 
-* **Manager with a local Ansible venv** (a self-bootstrapped manager): run
-  `osism update manager` on the manager itself — this is the path described below.
 * **Seed node still available** (a separate workstation or VM that holds the
   configuration repository, as in the [Seed deploy guide](../deploy-guide/seed.md)):
-  update from the seed instead of the manager. After bumping `manager_version`
-  (step 1) and syncing the configuration repository on the manager (step 2),
-  re-run the manager playbook from the seed:
+  update from the seed. This reuses the same tooling as the initial bootstrap, so
+  the manager itself needs no local Ansible installation. Run step 3 in the
+  `environments/manager` directory of the configuration repository on the seed.
+* **No seed node** (it was discarded after the deployment, or the manager was
+  bootstrapped by itself): run the update from the configuration repository on the
+  manager. `run.sh` ships in the repository and is refreshed by `make sync`
+  (step 1), so it does not depend on the tooling installed on the manager. Run
+  step 3 in `/opt/configuration/environments/manager`.
 
-    ```bash
-    ./run.sh manager
-    ```
-
-  This reuses the same seed tooling as the initial bootstrap, so the manager
-  itself needs no local Ansible installation.
-* **Manager deployed with the seed container, seed discarded** (the manager has
-  no local Ansible venv and no seed node remains): run the update from the
-  configuration repository on the manager itself. `run.sh` ships in the repository
-  and is refreshed by `make sync` (step 1), so it does not depend on the manager's
-  installed tooling. With a container engine present and no local venv it runs the
-  playbook inside the `osism/seed` container automatically (`SEED_CONTAINER=auto`):
-
-    ```bash
-    cd /opt/configuration/environments/manager
-    ./run.sh manager
-    ```
-
-  The vault password must be reachable — ship `environments/.vault_pass` in the
-  configuration repository or export `ANSIBLE_ASK_VAULT_PASS=true` (see the vault
-  note in step 3). Once the manager runs a release whose wrapper supports it,
-  `osism update manager` (`CONTAINER=auto`) does the same thing and can be used
-  instead.
+`run.sh` chooses how to execute the playbook by itself: with a container engine
+available it runs it inside the `osism/seed` container (`SEED_CONTAINER=auto`, the
+default), otherwise it uses a local Ansible venv. Set `SEED_CONTAINER=false` to
+force the venv path even when a container engine is present.
 
 :::
 
@@ -118,20 +103,23 @@ how you deployed the cluster. Steps 1, 2 and 4 to 6 are the same for all of them
     osism apply configuration
     ```
 
-3. Update the manager service on the manager node.
+3. Update the manager service. Run this in the `environments/manager` directory of the
+   configuration repository, on the seed node or on the manager itself — see the note
+   above for which applies to you.
 
-    ```console
-    osism update manager
+    ```bash
+    ./run.sh manager
     ```
 
-    * If Ansible Vault was used to encrypt `environments/manager/secrets.yml`, append
+    * If Ansible Vault was used to encrypt `environments/manager/secrets.yml`, pass
       `--ask-vault-pass` (or set `ANSIBLE_VAULT_PASSWORD_FILE` to the vault password file).
-      Unlike `osism apply`, `osism update manager` runs outside the OSISM workers — it
-      recreates the manager containers and therefore cannot use the worker-side vault
-      password set with `osism set vault password`. The password must be supplied directly
-      whenever `secrets.yml` is encrypted; the OSISM >= 8.0.0 relief from `--ask-vault-pass`
-      applies to `osism apply`, not to this command.
-    * If `osism update manager` does not work yet, use `osism-update-manager` instead.
+      Unlike `osism apply`, the playbook runs outside the OSISM workers — it recreates the
+      manager containers and therefore cannot use the worker-side vault password set with
+      `osism set vault password`. The password must be supplied directly whenever
+      `secrets.yml` is encrypted; the OSISM >= 8.0.0 relief from `--ask-vault-pass`
+      applies to `osism apply`, not here.
+    * Arguments after the playbook name are passed on to `ansible-playbook`, so
+      `./run.sh manager --ask-vault-pass` works as well.
 
 
 4. Refresh the facts cache.

--- a/docs/guides/upgrade-guide/manager.mdx
+++ b/docs/guides/upgrade-guide/manager.mdx
@@ -17,31 +17,6 @@ adjustments are necessary. Read the release notes even if you are only updating 
 The update of a manager service with a stable release of OSISM is described here.
 In the example, OSISM release 7.0.5 is used.
 
-:::info Which update path applies to you
-
-Step 3 below drives the `osism.manager.manager` playbook against the manager over
-SSH, with the `run.sh` script from the configuration repository. The playbook and
-the script are the same in every case; only where you run them depends on how you
-deployed the cluster. Steps 1, 2 and 4 to 6 are the same for all of them.
-
-* **Seed node still available** (a separate workstation or VM that holds the
-  configuration repository, as in the [Seed deploy guide](../deploy-guide/seed.md)):
-  update from the seed. This reuses the same tooling as the initial bootstrap, so
-  the manager itself needs no local Ansible installation. Run step 3 in the
-  `environments/manager` directory of the configuration repository on the seed.
-* **No seed node** (it was discarded after the deployment, or the manager was
-  bootstrapped by itself): run the update from the configuration repository on the
-  manager. `run.sh` ships in the repository and is refreshed by `make sync`
-  (step 1), so it does not depend on the tooling installed on the manager. Run
-  step 3 in `/opt/configuration/environments/manager`.
-
-`run.sh` chooses how to execute the playbook by itself: with a container engine
-available it runs it inside the `osism/seed` container (`SEED_CONTAINER=auto`, the
-default), otherwise it uses a local Ansible venv. Set `SEED_CONTAINER=false` to
-force the venv path even when a container engine is present.
-
-:::
-
 1. Change the OSISM release in the configuration repository.
 
     1. Set the new OSISM version in the configuration repository.
@@ -103,14 +78,22 @@ force the venv path even when a container engine is present.
     osism apply configuration
     ```
 
-3. Update the manager service. Run this in the `environments/manager` directory of the
-   configuration repository, on the seed node or on the manager itself — see the note
-   above for which applies to you.
+3. Update the manager service. The `osism.manager.manager` playbook is driven against
+   the manager over SSH, so this can run on any machine that has a checkout of the
+   configuration repository and can reach the manager — the machine the cluster was
+   deployed from, or the manager itself, where the repository is at
+   `/opt/configuration`. Run it in the `environments/manager` directory.
 
     ```bash
     ./run.sh manager
     ```
 
+    * `run.sh` ships in the configuration repository and is refreshed by `make sync`
+      (step 1), so it does not depend on the tooling installed on the machine that runs
+      it. It also chooses how to execute the playbook by itself: with a container engine
+      available it runs it inside the `osism/seed` container (`SEED_CONTAINER=auto`, the
+      default), otherwise it uses a local Ansible venv. Set `SEED_CONTAINER=false` to
+      force the venv path even when a container engine is present.
     * If Ansible Vault was used to encrypt `environments/manager/secrets.yml`, the vault
       password must be reachable. Its place in the configuration repository is
       `environments/.vault_pass`; `run.sh` finds that file on its own. It either contains

--- a/docs/guides/upgrade-guide/manager.mdx
+++ b/docs/guides/upgrade-guide/manager.mdx
@@ -111,13 +111,14 @@ force the venv path even when a container engine is present.
     ./run.sh manager
     ```
 
-    * If Ansible Vault was used to encrypt `environments/manager/secrets.yml`, pass
-      `--ask-vault-pass` (or set `ANSIBLE_VAULT_PASSWORD_FILE` to the vault password file).
-      Unlike `osism apply`, the playbook runs outside the OSISM workers — it recreates the
-      manager containers and therefore cannot use the worker-side vault password set with
-      `osism set vault password`. The password must be supplied directly whenever
-      `secrets.yml` is encrypted; the OSISM >= 8.0.0 relief from `--ask-vault-pass`
-      applies to `osism apply`, not here.
+    * If Ansible Vault was used to encrypt `environments/manager/secrets.yml`, the vault
+      password must be reachable. Its place in the configuration repository is
+      `environments/.vault_pass`; `run.sh` finds that file on its own. It either contains
+      the password or is an executable script that prints it — use the script form if the
+      password is kept elsewhere, for example in `secrets/vaultpass`.
+    * The playbook runs outside the OSISM workers — it recreates the manager containers —
+      so it cannot use the worker-side vault password set with `osism set vault password`.
+      The OSISM >= 8.0.0 relief from `--ask-vault-pass` applies to `osism apply`, not here.
     * Arguments after the playbook name are passed on to `ansible-playbook`, so
       `./run.sh manager --ask-vault-pass` works as well.
 

--- a/docs/testbed/usage.mdx
+++ b/docs/testbed/usage.mdx
@@ -126,7 +126,7 @@ of the other cloud is changed accordingly.
 1. Go to `/opt/configuration` on `testbed-manager`
 2. Run `./scripts/set-openstack-version.sh 2024.2` to set the OpenStack version to `2024.2`
 3. Run `./scripts/set-ceph-version.sh reef` to set the Ceph version to `reef`
-4. Run `osism update manager` to update the manager service
+4. Run `./environments/manager/run.sh manager` to update the manager service
 
 ### Deploy services
 


### PR DESCRIPTION
The manager upgrade guide told operators to run `osism update manager` in step 3. That
command has been removed:

- osism/ansible-collection-services#2154

`python-osism` has no `update` command of its own, so the dispatch in the `osism` wrapper
that PR deletes was the only implementation. This makes `./run.sh manager` — the manager
playbook run from the configuration repository — the documented way to update the manager.

Four commits:

1. **Document the update with `run.sh`.** Step 3 becomes `./run.sh manager`. Two further
   pages named the command and are updated too: the manager configuration guide and the
   testbed usage page.
2. **Name one place for the vault password.** The note listed the mechanisms that happen
   to work without saying where the password belongs. It now names
   `environments/.vault_pass`, the file `run.sh` detects by itself. Setting
   `ANSIBLE_VAULT_PASSWORD_FILE` is not equivalent: `run.sh` forwards it into the seed
   container unchanged, while the repository is always bind-mounted at
   `/opt/configuration` there, so a host path from a machine that keeps the repository
   elsewhere points at nothing inside the container. The venv path used to look for
   `.vault_pass` only in `environments/manager`; that gap is closed by

   - osism/generics#613

   which reaches a configuration repository with the next `make sync`, since gilt tracks
   generics at `main`.
3. **Stop branching on deployment shape.** Follows jklare's review. The "which update path
   applies to you" note is gone: a seed node holds no state the update needs, so how the
   cluster was deployed does not determine how it is updated. Step 3 now says the playbook
   is driven against the manager over SSH, so any machine with a checkout of the
   configuration repository that can reach the manager will do.
4. **Say where each upgrade step runs.** The steps do split by location, just not by
   deployment shape: steps 1 and 3 run in a checkout of the configuration repository,
   steps 2 and 4 to 6 use the `osism` command on the manager. The page never said so.

**Correct for managers on both sides of the removal.** `manager_old_wrapper_scripts` is
consumed by no task, so an already-deployed manager keeps its `osism-update-manager`; only
a manager built after #2154 lacks it. The guide has to work for both, and `./run.sh
manager` does: it ships in the configuration repository, is refreshed by `make sync` in
step 1, and does not depend on the tooling installed on the machine that runs it.

The release notes for OSISM 7 and 10 also mention the command and are left alone as a
record of what those releases documented. `release-notes/osism-10.md` phrases it as an
actionable upgrade instruction, though, so it may deserve an exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
