### PR TITLE
Add a MetalBox section to the Operations Guide

### DIFF
--- a/docs/concepts/metalbox.md
+++ b/docs/concepts/metalbox.md
@@ -230,7 +230,9 @@ The provisioning sequence is:
 
 For installing a MetalBox — including the air-gap procedures — see
 [Installation of the MetalBox](../guides/deploy-guide/metalbox.md) in the Deploy
-Guide. For keeping it up to date, see
+Guide. For deploying and redeploying nodes with it, see
+[MetalBox](../guides/operations-guide/metalbox/index.md) in the Operations Guide. For
+keeping it up to date, see
 [Data updates](../guides/upgrade-guide/metalbox/data-updates.md) and
 [Service updates](../guides/upgrade-guide/metalbox/service-updates.md) in the
 Upgrade Guide. The MetalBox itself is developed in the

--- a/docs/guides/deploy-guide/metalbox.md
+++ b/docs/guides/deploy-guide/metalbox.md
@@ -450,6 +450,8 @@ funzip osism-metalbox-image.zip | dd of=$DEVICE bs=4M status=progress
 
 ## Next steps
 
+* [Node deployment](../operations-guide/metalbox/node-deployment.md) — deploy the
+  bare-metal nodes of the CloudPod with the MetalBox.
 * [Data updates on the MetalBox](../upgrade-guide/metalbox/data-updates.md) —
   update the NetBox data, the Ironic images, the container registry, and the Ubuntu
   repository files.

--- a/docs/guides/operations-guide/baremetal/index.md
+++ b/docs/guides/operations-guide/baremetal/index.md
@@ -1,5 +1,0 @@
----
-sidebar_label: Baremetal
----
-
-# Baremetal

--- a/docs/guides/operations-guide/metalbox/hardware-replacement.md
+++ b/docs/guides/operations-guide/metalbox/hardware-replacement.md
@@ -1,0 +1,75 @@
+---
+sidebar_label: Hardware replacement
+sidebar_position: 30
+---
+
+# Hardware replacement
+
+Provisioning is driven from NetBox: the MetalBox reads the hardware inventory from it,
+creates the corresponding node in Ironic and generates the configuration for the first
+boot from it. When hardware of a node is replaced, the data in NetBox therefore has to
+be brought in line with reality before the node is provisioned again. Otherwise the
+node is deployed against the parameters of hardware it no longer has.
+
+The steps on this page apply to every node type. They are done while the node is out of
+service: for a node that is already in the environment, between taking it out and
+provisioning it again, see [Node redeployment](./node-redeployment.md).
+
+Which system each command runs on is given with every step, see
+[Where the commands run](./index.md#where-the-commands-run).
+
+## Checking the data in NetBox
+
+When components have been replaced, or when a node is commissioned for the first time,
+check the data recorded in NetBox and update it where needed:
+
+* **MAC addresses** — when a network card has been replaced, the MAC addresses recorded
+  so far have to be removed and the new ones added. They are part of the
+  provisioning-relevant data and have to match the installed hardware.
+* **Firmware versions and configuration** — check them against the state currently in
+  use and adjust where needed.
+
+Roll changes to the NetBox data out as described in
+[Update of the NetBox data](../../upgrade-guide/metalbox/data-updates.md#update-of-the-netbox-data).
+
+:::warning
+
+Changing a NetBox resource can be interpreted as adding a new resource, so that the
+previous one has to be deleted explicitly. This applies to changes in the repository as
+well as to applying them on the MetalBoxes.
+
+Changing a MAC address **adds** it to the existing ones. The previous MAC address has to
+be deleted manually, or NetBox has to be rebuilt completely. Delete the old MAC
+addresses in the GUI of the respective NetBox under `Addressing -> MAC Addresses`, using
+the filter to restrict the entries shown to the node in question, then select them and
+confirm the `Delete` function in the drop-down menu on the right. This has to be
+repeated on the NetBox instances of the MetalBox systems, because resource management is
+incremental there as well.
+
+:::
+
+## Applying the change to the baremetal service
+
+**MetalBox.** Once NetBox is correct, update the inventory and synchronize the node with
+the baremetal service so that Ironic picks up the changed parameters:
+
+```bash
+osism sync inventory
+osism sync ironic
+```
+
+**MetalBox.** To check that the change has actually landed, compare the parameters
+NetBox provides with the state Ironic holds for the node:
+
+```bash
+osism baremetal dump node101
+osism baremetal dump --ironic node101
+```
+
+The first renders the data from NetBox, the second the actual deployment state from
+Ironic.
+
+Once the data matches the hardware, continue with
+[Node deployment](./node-deployment.md) for a node that is provisioned for the first
+time, or with [Node redeployment](./node-redeployment.md) for a node that goes back into
+service.

--- a/docs/guides/operations-guide/metalbox/index.md
+++ b/docs/guides/operations-guide/metalbox/index.md
@@ -1,0 +1,42 @@
+---
+sidebar_label: MetalBox
+sidebar_key: operations-guide-metalbox
+---
+
+# MetalBox
+
+The MetalBox provisions the bare-metal nodes of a CloudPod through
+[OpenStack Ironic](https://docs.openstack.org/ironic/latest/). The following pages
+describe how nodes are deployed and redeployed with it.
+
+* [Node deployment](./node-deployment.md) — bring a new, empty node from its NetBox
+  entry to a running operating system. This is the generic case and the basis for
+  everything else.
+* [Node redeployment](./node-redeployment.md) — reprovision a node that is already in
+  service and redeploy the services of its role, including the removal and re-addition
+  of a compute node with its workload.
+* [Hardware replacement](./hardware-replacement.md) — the additional steps needed when
+  components of a node have been replaced, for any node type.
+
+The installation of a MetalBox is described in the
+[Deploy Guide](../../deploy-guide/metalbox.md), keeping it up to date in the
+[Upgrade Guide](../../upgrade-guide/metalbox/index.md), and its architecture in the
+[OSISM MetalBox](../../../concepts/metalbox.md) concept.
+
+## Where the commands run {#where-the-commands-run}
+
+The pages in this section switch between different systems, and running a command on
+the wrong one is the most common source of confusion:
+
+| Prompt       | System                                                               | Commands                                                                                                        |
+|:-------------|:---------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
+| **MetalBox** | The MetalBox itself, which runs Ironic and the NetBox it is fed from | `osism baremetal …`, `osism sync ironic`, and `osism sync inventory` for the MetalBox' own inventory            |
+| **Manager**  | The OSISM Manager of the CloudPod                                    | `osism apply …`, `osism manage compute …`, and `osism sync inventory` for the CloudPod inventory                |
+| **Node**     | A bare-metal node itself                                             | The few steps that have to be run on a node directly, such as removing a control node from the RabbitMQ cluster |
+
+The MetalBox and the Manager both run an OSISM Manager and both understand
+`osism sync inventory`, but they manage different inventories: the MetalBox drives the
+bare-metal life cycle below the CloudPod, the Manager deploys the services on top of
+it. The
+[OSISM MetalBox](../../../concepts/metalbox.md#osism-manager) concept explains the
+split in more detail.

--- a/docs/guides/operations-guide/metalbox/node-deployment.md
+++ b/docs/guides/operations-guide/metalbox/node-deployment.md
@@ -1,0 +1,163 @@
+---
+sidebar_label: Node deployment
+sidebar_position: 10
+---
+
+# Node deployment
+
+This page describes the generic case: a node that is described in NetBox but has never
+been provisioned is brought to a running operating system and handed over to the OSISM
+Manager of the CloudPod. Redeploying a node that is already in service is described in
+[Node redeployment](./node-redeployment.md).
+
+Which system each command runs on is given with every step, see
+[Where the commands run](./index.md#where-the-commands-run).
+
+## Prerequisites
+
+* The MetalBox is installed and the OpenStack services on it are deployed, see
+  [Installation of the MetalBox](../../deploy-guide/metalbox.md).
+* The Ironic images are uploaded to `/opt/httpd/data/root` on the MetalBox.
+* The node is described in NetBox: the device with its site, its MAC addresses, its
+  addressing, and the `ironic_parameters` custom field that carries the driver and BMC
+  information. If NetBox still has to be updated, roll the change out as described in
+  [Update of the NetBox data](../../upgrade-guide/metalbox/data-updates.md#update-of-the-netbox-data);
+  what to check when hardware was replaced is described in
+  [Hardware replacement](./hardware-replacement.md).
+
+## Provision states
+
+Ironic moves a node through provision states, and each of the `osism baremetal`
+commands only acts on nodes in specific ones. `provide` and `deploy` additionally skip
+nodes that are in maintenance mode.
+
+| Command                            | Acts on nodes in                                     | Result                                   |
+|:-----------------------------------|:-----------------------------------------------------|:-----------------------------------------|
+| `osism baremetal provide`          | `manageable`                                         | `available`                              |
+| `osism baremetal clean`            | `available`                                          | erases the disks, node stays `available` |
+| `osism baremetal burnin`           | `available`                                          | runs the selected burn-in tests          |
+| `osism baremetal deploy`           | `available`, `deploy failed`                         | `active`                                 |
+| `osism baremetal deploy --rebuild` | `active`, `error`                                    | `active`                                 |
+| `osism baremetal undeploy`         | `active`, `wait call-back`, `deploy failed`, `error` | `available`                              |
+
+A node that is in none of the listed states is skipped with a warning naming its
+current state, so a command that appears to do nothing is usually a node in an
+unexpected state rather than a failure.
+
+## Register the node in Ironic
+
+**MetalBox.** Read the inventory from NetBox and create or update the corresponding
+node in Ironic:
+
+```bash
+osism sync inventory
+osism sync ironic
+```
+
+`osism sync ironic` is what turns the NetBox device into an Ironic node. Run it again
+whenever provisioning-relevant data in NetBox has changed, for example after a network
+card was replaced.
+
+**MetalBox.** Check that the node is known and see which state it is in:
+
+```bash
+osism baremetal list
+```
+
+The output lists every node with its power state, provision state and maintenance
+flag. To see the device role from NetBox as well, add `--netbox`; to look at a single
+group of nodes, filter with `--provision-state` or `--maintenance`.
+
+## Prepare the node
+
+**MetalBox.** `osism sync ironic` already takes a newly registered node from `enroll`
+through `manageable` to `available`, which is the state a deployment starts from.
+Automated cleaning is skipped during that transition. A node that is left in
+`manageable`, for example after a failed cleaning, is moved on with:
+
+```bash
+osism baremetal provide node101
+```
+
+For hardware that is put into service for the first time, it is worth checking it
+before deploying anything on it. The burn-in reads out the system and exercises the
+selected components:
+
+```bash
+osism baremetal burnin --cpu --memory --disk node101
+```
+
+To erase the disks of a node before deploying, use:
+
+```bash
+osism baremetal clean node101
+```
+
+Cleaning runs in the `manageable` state, so the command moves the node there and back
+by itself. On nodes with a RAID interface the RAID configuration is deleted as part of
+it.
+
+## Deploy the node
+
+**MetalBox.** Write the operating system to the node:
+
+```bash
+osism baremetal deploy node101
+```
+
+The node boots the ironic-python-agent over virtual media, pulls the target image from
+the MetalBox and writes it to disk. The configuration for the first boot is generated
+from the `local_context_data` of the NetBox device, so the node configures itself when
+it comes up.
+
+Provisioning takes a while and ends in the `active` state. Follow it with:
+
+```bash
+watch osism baremetal list
+```
+
+## Hand the node over to the Manager
+
+Reaching `active` means the operating system has been written and the node is booting.
+Before any services can be deployed, the node has to be reachable over the network.
+
+**Manager.** Pick the new node up into the inventory of the CloudPod:
+
+```bash
+osism sync inventory
+```
+
+**Manager.** Wait until the node answers. The first command reports the current state,
+the second blocks until the node is reachable:
+
+```bash
+osism apply ping -- --limit node101
+osism apply wait-for-connection -- --limit node101
+```
+
+**Manager.** Bootstrap the node:
+
+```bash
+osism apply facts
+osism apply hosts
+osism apply bootstrap -- --limit node101
+osism apply sshconfig
+osism apply known-hosts
+```
+
+**Manager.** Apply the network configuration, reboot the node so that it takes effect,
+and wait for the node to come back:
+
+```bash
+osism apply network -- --limit node101
+osism apply reboot -- --limit node101 -e ireallymeanit=yes
+osism apply wait-for-connection -- --limit node101
+```
+
+The node is now a managed node of the CloudPod. What has to be deployed on top of this
+depends on the role of the node:
+
+* For the services of a full deployment, see
+  [Deployment of the services](../../deploy-guide/services/index.md).
+* For the role-specific steps when a single node is put back into service, see
+  [Node redeployment](./node-redeployment.md).

--- a/docs/guides/operations-guide/metalbox/node-deployment.md
+++ b/docs/guides/operations-guide/metalbox/node-deployment.md
@@ -44,6 +44,12 @@ A node that is in none of the listed states is skipped with a warning naming its
 current state, so a command that appears to do nothing is usually a node in an
 unexpected state rather than a failure.
 
+The states above are the ones the commands are built around. The complete state
+machine, including the intermediate and failure states a node passes through when a
+transition does not follow the expected path, is documented in
+[Ironic's node states](https://docs.openstack.org/ironic/latest/user/states.html). It is
+worth consulting whenever a node ends up in a state that is not listed here.
+
 ## Register the node in Ironic
 
 **MetalBox.** Read the inventory from NetBox and create or update the corresponding
@@ -128,7 +134,7 @@ osism sync inventory
 ```
 
 **Manager.** Wait until the node answers. The first command reports the current state,
-the second blocks until the node is reachable:
+the second blocks until the node is reachable via SSH:
 
 ```bash
 osism apply ping -- --limit node101
@@ -144,6 +150,13 @@ osism apply bootstrap -- --limit node101
 osism apply sshconfig
 osism apply known-hosts
 ```
+
+`bootstrap` only has to touch the new node, so it is limited to it. `facts`, `hosts`,
+`sshconfig` and `known-hosts` are run without `--limit` because they generate files from
+the data of all nodes: `/etc/hosts` is written on every node and has to contain the new
+node afterwards, and the `.ssh/config` and `known_hosts` of the Manager get an entry per
+node. Limiting them to the new node would leave the other nodes without its address and
+would write those files from incomplete data.
 
 **Manager.** Apply the network configuration, reboot the node so that it takes effect,
 and wait for the node to come back:

--- a/docs/guides/operations-guide/metalbox/node-redeployment.md
+++ b/docs/guides/operations-guide/metalbox/node-redeployment.md
@@ -80,7 +80,7 @@ connectivity of the node, either by polling:
 osism apply ping -- --limit node101
 ```
 
-or by blocking until the node answers:
+or by blocking until the node is reachable via SSH:
 
 ```bash
 osism apply wait-for-connection -- --limit node101
@@ -99,6 +99,9 @@ osism apply bootstrap -- --limit node101
 osism apply sshconfig
 osism apply known-hosts
 ```
+
+Why some of these commands are run without `--limit` is explained in
+[Node deployment](./node-deployment.md#hand-the-node-over-to-the-manager).
 
 **Manager.** Apply the network configuration, reboot the node so that it takes effect,
 and wait for the node to come back:
@@ -135,8 +138,8 @@ docker exec rabbitmq rabbitmqctl forget_cluster_node rabbit@ctl101
 
 :::
 
-**Manager.** Deploy the services of a control node in this order. The `--limit`
-parameter restricts the run to the group of controllers:
+**Manager.** Deploy the services of a control node in this order. The runs are limited to
+the `control` group, not to the reprovisioned node:
 
 ```bash
 osism apply common -- --limit control
@@ -158,6 +161,28 @@ osism apply neutron -- --limit control
 osism apply nova -- --limit control
 osism apply horizon -- --limit control
 ```
+
+The limit is the `control` group and not the single node that was reprovisioned. The
+control nodes are peers of one another, so a run against one of them alone is not enough:
+
+* The configuration of the other control nodes references the reprovisioned node. The
+  peer list in `rabbitmq.conf` and the `wsrep_cluster_address` of MariaDB are generated
+  from all members of the group, and every control node needs an `/etc/hosts` entry for
+  every other one. Those files are only rewritten on the nodes that are part of the run.
+* The playbooks determine the state of a cluster from the hosts of the run. MariaDB for
+  example decides from them whether the cluster already exists, whether it is stopped
+  and which member is in sync. A run that contains only the freshly installed node
+  answers those questions from a node that knows nothing of the running cluster.
+
+Deploying the whole group lets the reprovisioned node join the existing clusters and
+keeps the configuration of the other control nodes consistent with it. This is also what
+Kolla Ansible requires, see
+[Adding new controllers](https://docs.openstack.org/kolla-ansible/latest/user/adding-and-removing-hosts.html#adding-new-controllers).
+
+Network and compute nodes are not peers of the other nodes of their role. Their
+configuration refers to the control nodes, whose data Ansible collects even when they
+are not part of the run, and no other node has to be reconfigured because of them. The
+runs for those roles are therefore limited to the single node.
 
 ## Network
 

--- a/docs/guides/operations-guide/metalbox/node-redeployment.md
+++ b/docs/guides/operations-guide/metalbox/node-redeployment.md
@@ -1,0 +1,319 @@
+---
+sidebar_label: Node redeployment
+sidebar_position: 20
+---
+
+# Node redeployment
+
+Redeploying a node that is already in service consists of two parts: reprovisioning it
+with a fresh base system, and deploying the services of its role again. The first part
+is the same for every node type, the second depends on the role the node has.
+
+Which system each command runs on is given with every step, see
+[Where the commands run](./index.md#where-the-commands-run).
+
+Within a role there are normally redundant systems, so a single node can be
+reprovisioned while the environment keeps running. Check the quorum of the services on
+the node before taking it out, and shut the node down cleanly rather than cutting the
+power.
+
+:::warning
+
+Compute nodes carry workload. Their instances have to be migrated away and the node has
+to be removed from the OpenStack environment **before** it is reprovisioned. See
+[Compute](#compute) for the steps around the generic procedure below.
+
+:::
+
+The examples below use the node `node101`.
+
+## Reprovisioning
+
+**MetalBox.** Shut the node down. This can be done on the node itself or as a graceful
+power-off request through the BMC:
+
+```bash
+osism baremetal power off --soft node101
+```
+
+**MetalBox.** Watch the power state until the node is off:
+
+```bash
+watch osism baremetal list
+```
+
+**MetalBox.** Reprovision the node. Either in a single step:
+
+```bash
+osism baremetal deploy --rebuild node101
+```
+
+Or as an explicit undeploy:
+
+```bash
+osism baremetal undeploy node101
+```
+
+followed by a deploy:
+
+```bash
+osism baremetal deploy node101
+```
+
+The second form leaves the node in `available` in between. That allows further
+maintenance before the node is put back into service, such as replacing hardware,
+erasing the disks with `osism baremetal clean`, or running a burn-in. If hardware is
+replaced at this point, the data in NetBox has to be updated as well, see
+[Hardware replacement](./hardware-replacement.md).
+
+**MetalBox.** During provisioning the node passes through several states and ends in
+`active` once the operating system starts to boot. Follow it with:
+
+```bash
+watch osism baremetal list
+```
+
+**Manager.** Reaching `active` is not the same as being reachable. Check the network
+connectivity of the node, either by polling:
+
+```bash
+osism apply ping -- --limit node101
+```
+
+or by blocking until the node answers:
+
+```bash
+osism apply wait-for-connection -- --limit node101
+```
+
+## Deployment of the services
+
+**Manager.** Prepare the reprovisioned node. These steps are the same for every role:
+
+```bash
+osism sync inventory
+osism apply ping
+osism apply facts
+osism apply hosts
+osism apply bootstrap -- --limit node101
+osism apply sshconfig
+osism apply known-hosts
+```
+
+**Manager.** Apply the network configuration, reboot the node so that it takes effect,
+and wait for the node to come back:
+
+```bash
+osism apply network -- --limit node101
+osism apply reboot -- --limit node101 -e ireallymeanit=yes
+osism apply wait-for-connection -- --limit node101
+```
+
+Everything after this is role-specific.
+
+:::note
+
+The service lists below cover the roles of a standard environment. Depending on the
+configuration, further services are deployed on a node. `iscsi` and `multipathd` for
+example are only needed in environments that use them. Compare the lists with the
+services the environment actually runs.
+
+:::
+
+## Control
+
+:::warning
+
+Before the RabbitMQ service of a control node is redeployed, it has to be removed from
+the existing RabbitMQ cluster. The service must be stopped for this, which already
+happened when the node was powered off above. Connect to one of the **active** control
+nodes and remove the node from the cluster, here for `ctl101`:
+
+```bash
+docker exec rabbitmq rabbitmqctl forget_cluster_node rabbit@ctl101
+```
+
+:::
+
+**Manager.** Deploy the services of a control node in this order. The `--limit`
+parameter restricts the run to the group of controllers:
+
+```bash
+osism apply common -- --limit control
+osism apply loadbalancer -- --limit control
+osism apply redis -- --limit control
+osism apply memcached -- --limit control
+osism apply rabbitmq -- --limit control
+osism apply mariadb -- --limit control
+osism apply ovn -- --limit control
+osism apply opensearch -- --limit control
+osism apply prometheus -- --limit control
+osism apply grafana -- --limit control
+osism apply keystone -- --limit control
+osism apply glance -- --limit control
+osism apply designate -- --limit control
+osism apply placement -- --limit control
+osism apply cinder -- --limit control
+osism apply neutron -- --limit control
+osism apply nova -- --limit control
+osism apply horizon -- --limit control
+```
+
+## Network
+
+**Manager.** Deploy the services of a network node:
+
+```bash
+osism apply common -- --limit net101
+osism apply openvswitch -- --limit net101
+osism apply ovn -- --limit net101
+osism apply prometheus -- --limit net101
+osism apply designate -- --limit net101
+osism apply octavia -- --limit net101
+```
+
+## Compute
+
+Compute nodes carry workload, so the generic procedure above is framed by additional
+steps: the instances have to be migrated away and the node removed from the OpenStack
+environment first, and it has to be registered again afterwards. The same steps are
+used to decommission and commission hardware, and for maintenance such as replacing
+components. In the latter case they are combined with
+[Hardware replacement](./hardware-replacement.md).
+
+The examples in this section use the compute node `com101`.
+
+### Removing the node from the environment
+
+**Manager.** Disable the node so that no new instances are scheduled onto it:
+
+```bash
+osism manage compute disable com101
+```
+
+**Manager.** Migrate the instances of the node to other hypervisors:
+
+```bash
+osism manage compute migrate --yes com101
+```
+
+**Manager.** Verify that no instances are left on the node:
+
+```bash
+osism manage compute list com101
+```
+
+**MetalBox.** Once the node is empty, undeploy it and put it into maintenance mode. The
+undeploy is only needed for a complete reinstallation. To only shut the node down, skip
+it and use `osism baremetal power off com101` after setting maintenance mode:
+
+```bash
+osism baremetal undeploy com101
+osism baremetal maintenance set com101
+```
+
+Maintenance mode is what takes the node out of the active inventory of the Manager, so
+that the Manager can still be used for the rest of the environment.
+
+**Manager.** Pick up the change:
+
+```bash
+osism sync inventory
+```
+
+**Manager.** Remove the OpenStack resources that belong to the node. Skip this if the
+state on the node is kept and the node is put back into service unchanged, which is the
+case when no reinstallation is done:
+
+```bash
+openstack --os-cloud admin compute service list -f value -c ID --host com101 | while read -r ID; do \
+    openstack --os-cloud admin compute service delete $ID; done
+openstack --os-cloud admin network agent list -f value -c ID --host com101 | while read -r ID; do \
+    openstack --os-cloud admin network agent delete $ID; done
+```
+
+The node is now removed from the OpenStack environment and is managed through the
+MetalBox only.
+
+:::warning
+
+Avoid booting the compute node again with the system that is still installed on it, as it
+would register itself in the OpenStack environment again. If that happens, the steps
+above have to be repeated.
+
+:::
+
+### Putting the node back into service
+
+If hardware of the node was replaced while it was out of service, bring the data in
+NetBox in line with it first, see [Hardware replacement](./hardware-replacement.md).
+
+**MetalBox.** If the node is already recorded on the MetalBox, remove the maintenance
+mode:
+
+```bash
+osism baremetal maintenance unset com101
+```
+
+**MetalBox.** If provisioning-relevant parameters such as MAC addresses have changed, or
+if the node was not managed on a MetalBox before, further fields in NetBox have to be
+updated. This happens automatically with a sync of the inventory, after which the data is
+synchronized with the baremetal service:
+
+```bash
+osism sync inventory
+osism sync ironic
+```
+
+**MetalBox.** Provision the node with the operating system. This is only needed if the
+node was undeployed above. Otherwise start it again with
+`osism baremetal power on com101`:
+
+```bash
+osism baremetal deploy com101
+```
+
+**Manager.** Continue with
+[Deployment of the services](#deployment-of-the-services) to take the node back into
+the inventory and bootstrap it, with `--limit com101` in place of `--limit node101`.
+
+### Deploying the compute services
+
+:::note
+
+If the compute node uses local storage for Nova, that storage has to be prepared before
+Nova is deployed, and any leftovers of a previous installation have to be cleared on the
+node first. How local storage is laid out differs per environment and is not covered by
+the OSISM tooling, so this step is done manually or with a custom playbook.
+
+:::
+
+**Manager.** Deploy the services of the compute node:
+
+```bash
+osism apply common -- --limit com101
+osism apply openvswitch -- --limit com101
+osism apply ovn -- --limit com101
+osism apply prometheus -- --limit com101
+osism apply neutron -- --limit com101
+osism apply nova -- --limit com101
+```
+
+:::note
+
+If the node was not reinstalled, its compute service was never deleted and still carries
+the `disable` from the beginning of this procedure. Enable it again so that instances are
+scheduled onto it:
+
+```bash
+osism manage compute enable com101
+```
+
+After a complete reinstallation this is not needed. The compute service is registered
+again from scratch and is enabled by default.
+
+:::
+
+The node is set up as an OpenStack compute node in the OSISM environment again. Depending
+on the previous configuration, it still has to be placed into the correct availability
+zone.


### PR DESCRIPTION
Adds a MetalBox section to the Operations Guide. Follow-up to #1054, which covered
installing a MetalBox and keeping it up to date, but not what it is installed for:
deploying and redeploying the bare-metal nodes of a CloudPod with it.

| Page | Content |
|:--|:--|
| `operations-guide/metalbox/index.md` | Overview and a **Where the commands run** table |
| `operations-guide/metalbox/node-deployment.md` | The generic case: a node described in NetBox that has never been provisioned |
| `operations-guide/metalbox/node-redeployment.md` | Reprovisioning a node that is in service, plus the role-specific service deployment for control, network and compute nodes |
| `operations-guide/metalbox/hardware-replacement.md` | The additional steps needed when components of a node have been replaced |

The empty `Baremetal` placeholder of the Operations Guide is renamed for this, so the
category is called MetalBox in every guide, as it already is in the Deploy,
Configuration and Upgrade guides.

## Where the content comes from

The role-specific procedures are based on internal notes on rebuilding node types and on
the compute node lifecycle. Everything else was derived from `osism/python-osism`,
mainly `osism/commands/baremetal.py` and `osism/tasks/conductor/ironic.py`. Two things
worth calling out because they are easy to get wrong and are documented here explicitly:

- **`osism sync ironic` already brings a new node to `available`.** It walks the node
  from `enroll` through `manageable` to `available` and skips automated cleaning for
  that transition, so `osism baremetal provide` is not a routine step. It is only needed
  for a node that is left in `manageable`, for example after a failed cleaning.
- **Only `provide` and `deploy` skip nodes in maintenance mode.** `clean` and `burnin`
  mention maintenance in their warning text but gate on the provision state alone, and
  `undeploy` does not check it at all. The provision-state table on the node deployment
  page states which command acts on which state.

The pages use `osism baremetal …` rather than the `osism manage baremetal …` alias, and
generic host names throughout.

## Scope

The service lists cover a standard environment. Which services a node actually runs
depends on the configuration, which the pages say rather than implying the lists are
complete — `iscsi` and `multipathd` are left out for that reason. The handling of local
storage on a compute node is not covered by the OSISM tooling and is only named as a
step that has to be done separately, manually or with a custom playbook.

## Verified

`yarn build` passes with `onBrokenLinks: 'throw'` and no broken-anchor warnings.
MegaLinter (documentation flavor, as in CI) is clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
