### PR TITLE
release-notes: drop osism update manager from 10

### DIFF
--- a/docs/release-notes/osism-10.md
+++ b/docs/release-notes/osism-10.md
@@ -189,7 +189,8 @@ queues there when upgrading the services.
 
 When the Manager's listener service is used (`enable_listener` in `environments/manager/configuration.yml`)
 add the new `openstack` RabbitMQ vhost to the `manager_listener_broker_uri` parameter.
-Then update the manager with `osism update manager` and delete the old queues with
+Then update the manager service as described in the
+[Upgrade Guide](../guides/upgrade-guide/manager.mdx) and delete the old queues with
 `osism migrate rabbitmq3to4 delete manager`.
 
 Finally, you can re-run the check command. There should now be no more classic queues.


### PR DESCRIPTION
The RabbitMQ 3 to 4 migration section in the OSISM 10 release notes tells operators with
the Manager listener enabled to update the manager with `osism update manager`
(`osism-10.md:192`). That command no longer exists:

- osism/ansible-collection-services#2154

`python-osism` registers no `update` command of its own, so the dispatch that PR removed
from the `osism` wrapper was the command's entire implementation. An operator working
through the migration now gets `'update manager' is not an osism command` at that step.

This is the one release-notes mention that is not a record of what a release documented at
the time — it sits inside a numbered procedure operators still follow. It now points at
the manager upgrade guide instead of naming a command, which is where the update is
described in full and stays correct as the mechanism changes. The same section already
links there in its introduction (`osism-10.md:8`).

**Merge after** the upgrade guide rewrite, or the link leads from one dead command to
another:

- osism/osism.github.io#1056

Draft until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
