### PR TITLE
manager: refresh the upgrade guide

### DIFF
--- a/docs/guides/upgrade-guide/manager.mdx
+++ b/docs/guides/upgrade-guide/manager.mdx
@@ -19,10 +19,11 @@ In the example, OSISM release 10.1.0 is used.
 
 :::info Where these steps run
 
-Steps 1 and 3 are run in a checkout of the configuration repository — the machine
+Steps 1 to 3 are run in a checkout of the configuration repository — the machine
 the cluster was deployed from, or the manager itself, where the repository is at
-`/opt/configuration`. Steps 2 and 4 to 6 use the `osism` command and are run on the
-manager.
+`/opt/configuration`. Steps 2 and 3 run `run.sh` from the `environments/manager`
+directory of that checkout, the same way the manager was deployed. Steps 4 to 6
+use the `osism` command and are run on the manager.
 
 Step 1 pushes the change and step 2 pulls it onto the manager, so both checkouts
 are at the same commit by the time step 3 runs.
@@ -86,30 +87,23 @@ are at the same commit by the time step 3 runs.
 
 2. Update the configuration repository on the manager node.
 
-    ```console
-    osism apply configuration
-    ```
-
-3. Update the manager service. Run this in the `environments/manager` directory of the
-   configuration repository.
-
     ```bash
-    ./run.sh manager
+    ./run.sh configuration
     ```
 
-    * The `osism.manager.manager` playbook is driven against the manager over SSH, so it
-      does not matter which machine runs it, as long as that machine has a checkout of
-      the configuration repository and can reach the manager.
+    * The playbooks in steps 2 and 3 are driven against the manager over SSH, so it does
+      not matter which machine runs them, as long as that machine has a checkout of the
+      configuration repository and can reach the manager.
     * `run.sh` ships in the configuration repository and is refreshed by `make sync`
       (step 1). Note that `make sync` pins it to the release you are upgrading **to**:
       it rewrites the `version` in `gilt.yml` to that release's `generics_version`, so
       the `run.sh` you end up with is the one that release ships, not the newest one.
-      How the playbook is executed follows from that:
+      How these playbooks are executed follows from that:
 
         <Tabs>
         <TabItem value="runsh-11" label="OSISM >= 10.2.0 and latest">
 
-        `run.sh` runs the playbook inside the `osism/seed` container when a container
+        `run.sh` runs a playbook inside the `osism/seed` container when a container
         engine is available (`SEED_CONTAINER=auto`, the default), so it does not depend
         on the Ansible tooling installed on the machine that runs it. Set
         `SEED_CONTAINER=false` to force a local Ansible venv instead.
@@ -119,9 +113,9 @@ are at the same commit by the time step 3 runs.
 
         These releases pin a `generics_version` older than the seed-container support,
         so their `run.sh` has no container path — it always builds a local Ansible venv
-        under `environments/manager`. The machine running this step therefore needs
+        under `environments/manager`. The machine running steps 2 and 3 therefore needs
         `python3-venv` and access to PyPI. A manager deployed with the seed container
-        does not necessarily have `python3-venv`; in that case run this step from the
+        does not necessarily have `python3-venv`; in that case run both steps from the
         machine the cluster was deployed from, or install `python3-venv` on the manager
         first.
 
@@ -136,14 +130,24 @@ are at the same commit by the time step 3 runs.
       `environments/.vault_pass`; `run.sh` finds that file on its own. It either contains
       the password or is an executable script that prints it — use the script form if the
       password is kept elsewhere, for example in `secrets/vaultpass`.
-    * The playbook runs outside the OSISM workers — it recreates the manager containers —
-      so it cannot use the worker-side vault password set with `osism set vault password`.
-      The OSISM >= 8.0.0 relief from `--ask-vault-pass` applies to `osism apply`, not here.
+    * Unlike `osism apply`, these playbooks run outside the OSISM workers, so they cannot
+      use the worker-side vault password set with `osism set vault password`. The
+      OSISM >= 8.0.0 relief from `--ask-vault-pass` applies to `osism apply`, not here.
     * Arguments after the playbook name are passed on to `ansible-playbook`, so
-      `./run.sh manager --ask-vault-pass` works as well.
+      `./run.sh configuration --ask-vault-pass` works as well.
+
+3. Update the manager service.
+
+    ```bash
+    ./run.sh manager
+    ```
+
+    * This recreates the manager containers. The notes on `run.sh` in step 2 apply here
+      as well.
 
 
-4. Refresh the facts cache.
+4. Refresh the facts cache. This and the remaining steps use the `osism` command, so
+   log in to the manager node that was just updated first.
 
     ```console
     osism apply facts

--- a/docs/guides/upgrade-guide/manager.mdx
+++ b/docs/guides/upgrade-guide/manager.mdx
@@ -46,36 +46,9 @@ are at the same commit by the time step 3 runs.
 
     3. Sync the image versions and files in the configuration repository.
 
-        <Tabs>
-        <TabItem value="osism-7" label="OSISM >= 7.0.0">
-
         ```bash
         make sync
         ```
-
-        </TabItem>
-        <TabItem value="osism-6" label="OSISM < 7.0.0">
-
-        If Gilt is not installed via the `requirements.txt` of the manager environment it is
-        important to use a version smaller v2. The v2 of Gilt is not yet usable.
-
-        ```bash
-        gilt overlay  # you have to do this 2x, this is not a copy & paste error
-        gilt overlay
-        ```
-
-        Optionally, this is normally not necessary, it is possible to reference a specific tag of the
-        [osism/generics](https://github.com/osism/generics) repository. To do this, first
-        check which version of osism/generics is used in a particular release. The version is
-        defined in `generics_version` in the `base.yml` file in the `osism/release` repository. For OSISM 6.0.0,
-        for example, this is version [v0.20230919.0](https://github.com/osism/release/blob/main/6.0.0/base.yml#L6).
-        This version is then added to the file `gilt.yml` in the configuration repository instead of
-        `main` at `version`. This change must be made again after each execution of `gilt overlay` as
-        it is overwritten by the call of `gilt overlay`. This cannot be realized differently in the
-        current implementation of [Gilt](https://github.com/retr0h/gilt).
-
-        </TabItem>
-        </Tabs>
 
     4. Commit and push all changes in the configuration repository. Since everyone here has their own
          workflows for changes to the configuration repository, only a generic example for Git.

--- a/docs/guides/upgrade-guide/manager.mdx
+++ b/docs/guides/upgrade-guide/manager.mdx
@@ -10,12 +10,12 @@ import TabItem from '@theme/TabItem';
 :::warning
 
 Always read the [release notes](https://osism.tech/docs/release-notes/) first to learn what has changed and what
-adjustments are necessary. Read the release notes even if you are only updating from e.g. 7.0.2 to 7.0.5.
+adjustments are necessary. Read the release notes even if you are only updating from e.g. 10.0.0 to 10.1.0.
 
 :::
 
 The update of a manager service with a stable release of OSISM is described here.
-In the example, OSISM release 7.0.5 is used.
+In the example, OSISM release 10.1.0 is used.
 
 :::info Where these steps run
 
@@ -34,7 +34,7 @@ are at the same commit by the time step 3 runs.
     1. Set the new OSISM version in the configuration repository.
 
          ```bash
-         MANAGER_VERSION=7.0.5
+         MANAGER_VERSION=10.1.0
          sed -i -e "s/manager_version: .*/manager_version: ${MANAGER_VERSION}/g" environments/manager/configuration.yml
          ```
 
@@ -80,7 +80,7 @@ are at the same commit by the time step 3 runs.
          workflows for changes to the configuration repository, only a generic example for Git.
 
         ```bash
-        git commit -a -s -m "manager: use OSISM version 7.0.5"
+        git commit -a -s -m "manager: use OSISM version 10.1.0"
         git push
         ```
 

--- a/docs/guides/upgrade-guide/manager.mdx
+++ b/docs/guides/upgrade-guide/manager.mdx
@@ -146,22 +146,26 @@ are at the same commit by the time step 3 runs.
       as well.
 
 
-4. Refresh the facts cache. This and the remaining steps use the `osism` command, so
-   log in to the manager node that was just updated first.
+4. Make the Ansible vault password known again. This and the remaining steps use the
+   `osism` command, so log in to the manager node that was just updated first.
+
+    ```console
+    osism set vault password
+    ```
+
+    * Step 3 recreated the manager containers, which discards the password held by the
+      OSISM workers. The `osism apply` runs below need it whenever `secrets.yml` is
+      encrypted, so set it before them rather than after.
+
+5. Refresh the facts cache.
 
     ```console
     osism apply facts
     ```
 
-5. If Traefik is used on the manager node (`traefik_enable: true` in `environments/infrastructure/configuration.yml`)
+6. If Traefik is used on the manager node (`traefik_enable: true` in `environments/infrastructure/configuration.yml`)
    then Traefik should also be upgraded.
 
     ```console
     osism apply traefik
-    ```
-
-6. Finally, the Ansible vault password must be made known again.
-
-    ```console
-    osism set vault password
     ```


### PR DESCRIPTION
Four independent changes to the manager upgrade guide, one per commit.
Rebased onto #1061 (`manager: gate run.sh execution note by release`) —
see the note at the bottom for what that changed here.

### `manager: update the example to OSISM 10.1.0`

The guide used 7.0.5 throughout as the release being upgraded to. OSISM 7 is
end of life, so the example pointed at a release nobody should upgrade to.
The warning above the steps moves from `7.0.2 → 7.0.5` to `10.0.0 → 10.1.0`
as its example of an update small enough to tempt someone into skipping the
release notes.

### `manager: pull the configuration with run.sh`

Step 2 pulled the pushed configuration onto the manager with
`osism apply configuration`, which has to run on the manager. Steps 1 and 3
run in a checkout of the configuration repository, so the guide sent readers
to the manager and back for a single command, then to the manager again for
the rest. Step 2 now runs `./run.sh configuration` from the checkout — the
same playbook and wrapper the deploy guide uses to transfer the configuration
repository during the initial deployment. Steps 1 to 3 all happen in the
checkout and steps 4 to 6 on the manager: one switch instead of three.

The notes below step 3 described `run.sh` in general rather than the manager
playbook, so they move up to step 2 where the script is first used. **The
vault note moves with them, and that is the one behavioural change worth a
close look:** `osism apply configuration` could use the worker-side password
from `osism set vault password`, `./run.sh configuration` cannot. An encrypted
`secrets.yml` now needs `environments/.vault_pass` (or `--ask-vault-pass`) one
step earlier than before.

The `python3-venv` requirement from #1061 does not become a new burden: on
releases below 10.2.0 step 3 already built that venv on whichever machine ran
it, so step 2 needs nothing step 3 did not already need.

### `manager: set the vault password before the applies`

`osism set vault password` was the last step, after `osism apply facts` and
`osism apply traefik`. Step 3 recreates the manager containers, so the password
held by the workers is gone by the time those two run — and with an encrypted
`secrets.yml` they need it. It is now step 4, the first command after the login.

### `manager: drop the pre-7 gilt instructions`

Step 1.3 offered `make sync` for OSISM >= 7.0.0 and `gilt overlay` for anything
older. No supported release takes the second tab, which carried the most
involved text on the page: running gilt twice, the gilt v2 warning, and pinning
a generics tag through `gilt.yml`. The `Tabs` imports stay — step 2 uses them.

---

### Changed by the rebase onto #1061

That commit rewrote the `run.sh` paragraph this branch moves from step 3 to
step 2, so the conflict was resolved in its favour: the release-gated tabs and
the `make sync` pinning explanation are kept verbatim, with the wording widened
from one step to both (`this step` → `steps 2 and 3`).

It also re-introduced `<Tabs>` to the page, which dropped a fifth commit that
renamed the guide to `.md` on the grounds that no MDX was left. The page stays
`.mdx` and all links to it are untouched.

Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)