### PR TITLE
manager: gate run.sh execution note by release

### DIFF
--- a/docs/guides/upgrade-guide/manager.mdx
+++ b/docs/guides/upgrade-guide/manager.mdx
@@ -101,11 +101,36 @@ are at the same commit by the time step 3 runs.
       does not matter which machine runs it, as long as that machine has a checkout of
       the configuration repository and can reach the manager.
     * `run.sh` ships in the configuration repository and is refreshed by `make sync`
-      (step 1), so it does not depend on the tooling installed on the machine that runs
-      it. It also chooses how to execute the playbook by itself: with a container engine
-      available it runs it inside the `osism/seed` container (`SEED_CONTAINER=auto`, the
-      default), otherwise it uses a local Ansible venv. Set `SEED_CONTAINER=false` to
-      force the venv path even when a container engine is present.
+      (step 1). Note that `make sync` pins it to the release you are upgrading **to**:
+      it rewrites the `version` in `gilt.yml` to that release's `generics_version`, so
+      the `run.sh` you end up with is the one that release ships, not the newest one.
+      How the playbook is executed follows from that:
+
+        <Tabs>
+        <TabItem value="runsh-11" label="OSISM >= 10.2.0 and latest">
+
+        `run.sh` runs the playbook inside the `osism/seed` container when a container
+        engine is available (`SEED_CONTAINER=auto`, the default), so it does not depend
+        on the Ansible tooling installed on the machine that runs it. Set
+        `SEED_CONTAINER=false` to force a local Ansible venv instead.
+
+        </TabItem>
+        <TabItem value="runsh-10" label="OSISM < 10.2.0">
+
+        These releases pin a `generics_version` older than the seed-container support,
+        so their `run.sh` has no container path — it always builds a local Ansible venv
+        under `environments/manager`. The machine running this step therefore needs
+        `python3-venv` and access to PyPI. A manager deployed with the seed container
+        does not necessarily have `python3-venv`; in that case run this step from the
+        machine the cluster was deployed from, or install `python3-venv` on the manager
+        first.
+
+        `run.sh` also refuses to run unless `configuration_git_version` in
+        `environments/manager/configuration.yml` names the branch the checkout is on
+        (see step 2 of the [manager configuration guide](../configuration-guide/manager.mdx)).
+
+        </TabItem>
+        </Tabs>
     * If Ansible Vault was used to encrypt `environments/manager/secrets.yml`, the vault
       password must be reachable. Its place in the configuration repository is
       `environments/.vault_pass`; `run.sh` finds that file on its own. It either contains


### PR DESCRIPTION
Follow-up to #1056. Step 3 of the manager upgrade guide describes how `run.sh`
executes the playbook. That description is only true for `latest` — **no
released version of OSISM behaves that way.**

## The claim on main today

> It also chooses how to execute the playbook by itself: with a container engine
> available it runs it inside the `osism/seed` container (`SEED_CONTAINER=auto`,
> the default), otherwise it uses a local Ansible venv. Set `SEED_CONTAINER=false`
> to force the venv path even when a container engine is present.

## Why it is wrong

Seed-container dispatch is osism/generics `9c04ed8`, first tagged
`v0.20260627.0`. Which `run.sh` an operator receives is not decided by generics
main: `generics/src/set-versions.py` runs as a gilt `post_command` and rewrites
`gilt.yml`'s `version` to the `generics_version` of the release named in
`manager_version`. So `make sync` delivers the `run.sh` of the release being
upgraded **to** — the committed `version: main` is only the value each overlay
resets before `set-versions.py` overwrites it.

| release | `generics_version` | seed path in `run.sh` |
|---|---|---|
| 9.5.0 | v0.20251130.0 | no |
| 10.0.0 | v0.20260319.0 | no |
| 10.1.0 | v0.20260615.0 | no |
| latest | v0.20260721.0 | yes |

On every release up to 10.1.0 `run.sh` has no container path at all and always
builds a local Ansible venv. That also falsifies the sentence before it — there,
`run.sh` very much depends on the tooling installed on the machine that runs it,
because it needs `python3-venv`. A manager deployed with the seed container has
no reason to carry `python3-venv`, and that is exactly the shape the wording
sends to the manager.

This was found by `testbed-upgrade-stable-ubuntu-24.04` failing on the same
premise — osism/testbed#2945 has the CI evidence.

## The change

Two tabs, in the style step 1 already uses, with the pin named as the reason so
the boundary can be checked rather than trusted. The `<= 10.1.0` tab adds the two
requirements of the venv path: `python3-venv`, and a `configuration_git_version`
matching the checked-out branch, which `run.sh` verifies before doing anything.

The command itself is unchanged. Pointing back at `osism update manager` for
those releases would not help — it defaults to `CONTAINER=false` and builds the
same venv, and its container path at that pin is the pre-#2125 fossil that mounts
the configuration repository read-only and wires neither the vault password nor
the operator key.

## The `python3-venv` requirement is observed, not inferred

A manager deployed with the seed container has no local Ansible venv and no
reason to carry `python3-venv` — the deploy never needs one. That is exactly the
shape the previous wording sent to the manager. Moving such a manager to 10.1.0
with `./run.sh manager` fails during the venv build:

```
The virtual environment was not created successfully because ensurepip is not
available.  On Debian/Ubuntu systems, you need to install the python3-venv
    apt install python3.12-venv
./run.sh: line 37: venv/bin/activate: No such file or directory
```

`run.sh` then stops at its own `ansible-playbook not installed` guard, leaving a
partial venv (`bin/`, `include/`, `lib/`, no `bin/activate`) that blocks a retry
until it is deleted. Installing `python3.12-venv` and removing the partial venv
makes the same command succeed. The same manager moved to `latest` takes the
container path and needs none of this — which is the boundary this PR documents.

## Verified

`npm run build` succeeds, and both tabs render in
`build/docs/guides/upgrade-guide/manager/index.html` (nesting `<Tabs>` inside a
list bullet was the part worth checking).

## Context

- osism/osism.github.io#1056
- osism/testbed#2945
- osism/ansible-collection-services#2125
- osism/ansible-collection-services#2154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
