### PR TITLE
Document rolling and release Kolla image tags

### DIFF
--- a/docs/appendix/security/ossa-2026-001.md
+++ b/docs/appendix/security/ossa-2026-001.md
@@ -109,6 +109,24 @@ that includes the fix. Configure the following in `environments/kolla/images.yml
 keystone_tag: "2024.2"  # or "2025.1", depending on your OpenStack release
 ```
 
+:::warning
+Rolling tags exist only in the `kolla` namespace. In a deployment that uses an OSISM release namespace
+(`docker_namespace: kolla/release/<openstack_version>`), the tag override above resolves to images that do
+not exist and the pull fails with `unknown: artifact ... not found`. Because `keystone_tag` applies to all
+Keystone images, each of them has to be overridden as well, so that they are pulled from the `kolla`
+namespace:
+
+```yaml
+keystone_image: "registry.osism.tech/kolla/keystone"
+keystone_fernet_image: "registry.osism.tech/kolla/keystone-fernet"
+keystone_ssh_image: "registry.osism.tech/kolla/keystone-ssh"
+keystone_httpd_image: "registry.osism.tech/kolla/httpd"
+keystone_tag: "2024.2"  # or "2025.1", depending on your OpenStack release
+```
+
+See [Rolling tags and release tags](../../guides/configuration-guide/openstack/index.md#rolling-tags-and-release-tags).
+:::
+
 ### Mitigation
 
 If you use external OAuth 2.0 authentication, consider the following measures:

--- a/docs/appendix/security/ossa-2026-002.md
+++ b/docs/appendix/security/ossa-2026-002.md
@@ -92,6 +92,31 @@ that include the fix. Configure the following in `environments/kolla/images.yml`
 nova_tag: "2024.2"  # or "2025.1", depending on your OpenStack release
 ```
 
+:::warning
+Rolling tags exist only in the `kolla` namespace. In a deployment that uses an OSISM release namespace
+(`docker_namespace: kolla/release/<openstack_version>`), the tag override above resolves to images that do
+not exist and the pull fails with `unknown: artifact ... not found`. Because `nova_tag` applies to all Nova
+images, each of them has to be overridden as well, so that they are pulled from the `kolla` namespace:
+
+```yaml
+nova_api_image: "registry.osism.tech/kolla/nova-api"
+nova_compute_image: "registry.osism.tech/kolla/nova-compute"
+nova_compute_ironic_image: "registry.osism.tech/kolla/nova-compute-ironic"
+nova_conductor_image: "registry.osism.tech/kolla/nova-conductor"
+nova_novncproxy_image: "registry.osism.tech/kolla/nova-novncproxy"
+nova_scheduler_image: "registry.osism.tech/kolla/nova-scheduler"
+nova_serialproxy_image: "registry.osism.tech/kolla/nova-serialproxy"
+nova_spicehtml5proxy_image: "registry.osism.tech/kolla/nova-spicehtml5proxy"
+nova_ssh_image: "registry.osism.tech/kolla/nova-ssh"
+nova_super_conductor_image: "registry.osism.tech/kolla/nova-super-conductor"
+nova_tag: "2024.2"  # or "2025.1", depending on your OpenStack release
+```
+
+Only the images actually used in the deployment need to be set. `nova_libvirt_tag` is not derived from
+`nova_tag` and is therefore not affected by this override. See
+[Rolling tags and release tags](../../guides/configuration-guide/openstack/index.md#rolling-tags-and-release-tags).
+:::
+
 ### Mitigation
 
 If you are using the flat image backend with `use_cow_images=False`, consider the following

--- a/docs/appendix/security/ossa-2026-005.md
+++ b/docs/appendix/security/ossa-2026-005.md
@@ -89,6 +89,24 @@ that includes the fix. Configure the following in `environments/kolla/images.yml
 keystone_tag: "2024.2"  # or "2025.1", depending on your OpenStack release
 ```
 
+:::warning
+Rolling tags exist only in the `kolla` namespace. In a deployment that uses an OSISM release namespace
+(`docker_namespace: kolla/release/<openstack_version>`), the tag override above resolves to images that do
+not exist and the pull fails with `unknown: artifact ... not found`. Because `keystone_tag` applies to all
+Keystone images, each of them has to be overridden as well, so that they are pulled from the `kolla`
+namespace:
+
+```yaml
+keystone_image: "registry.osism.tech/kolla/keystone"
+keystone_fernet_image: "registry.osism.tech/kolla/keystone-fernet"
+keystone_ssh_image: "registry.osism.tech/kolla/keystone-ssh"
+keystone_httpd_image: "registry.osism.tech/kolla/httpd"
+keystone_tag: "2024.2"  # or "2025.1", depending on your OpenStack release
+```
+
+See [Rolling tags and release tags](../../guides/configuration-guide/openstack/index.md#rolling-tags-and-release-tags).
+:::
+
 ### Mitigation
 
 If you are using restricted application credentials with the EC2/S3 API, consider the

--- a/docs/appendix/security/ossa-2026-015.md
+++ b/docs/appendix/security/ossa-2026-015.md
@@ -154,6 +154,24 @@ image.
 
 :::
 
+:::warning
+Rolling tags exist only in the `kolla` namespace. In a deployment that uses an OSISM release namespace
+(`docker_namespace: kolla/release/<openstack_version>`), the tag override above resolves to images that do
+not exist and the pull fails with `unknown: artifact ... not found`. Because `keystone_tag` applies to all
+Keystone images, each of them has to be overridden as well, so that they are pulled from the `kolla`
+namespace:
+
+```yaml
+keystone_image: "registry.osism.tech/kolla/keystone"
+keystone_fernet_image: "registry.osism.tech/kolla/keystone-fernet"
+keystone_ssh_image: "registry.osism.tech/kolla/keystone-ssh"
+keystone_httpd_image: "registry.osism.tech/kolla/httpd"
+keystone_tag: "2025.1"  # or "2024.1", "2024.2", "2025.2", depending on your OpenStack release
+```
+
+See [Rolling tags and release tags](../../guides/configuration-guide/openstack/index.md#rolling-tags-and-release-tags).
+:::
+
 ### Mitigation
 
 Because all deployments are affected and the vulnerabilities require only authenticated access,

--- a/docs/appendix/security/ossa-2026-022.md
+++ b/docs/appendix/security/ossa-2026-022.md
@@ -121,6 +121,20 @@ image. Using rolling tags, configure the following in `environments/kolla/images
 nova_api_tag: "2025.1"  # or "2024.1", "2024.2", "2025.2", depending on your OpenStack release
 ```
 
+:::warning
+Rolling tags exist only in the `kolla` namespace. In a deployment that uses an OSISM release namespace
+(`docker_namespace: kolla/release/<openstack_version>`), the tag override above resolves to an image that
+does not exist and the pull fails with `unknown: artifact ... not found`. The image parameter has to be
+overridden as well, so that this image is pulled from the `kolla` namespace:
+
+```yaml
+nova_api_image: "registry.osism.tech/kolla/nova-api"
+nova_api_tag: "2025.1"  # or "2024.1", "2024.2", "2025.2", depending on your OpenStack release
+```
+
+See [Rolling tags and release tags](../../guides/configuration-guide/openstack/index.md#rolling-tags-and-release-tags).
+:::
+
 ### Mitigation
 
 Because all deployments are affected and exploitation requires only an authenticated user that can

--- a/docs/appendix/security/ossa-2026-032.md
+++ b/docs/appendix/security/ossa-2026-032.md
@@ -206,6 +206,22 @@ The vulnerable code path runs in the Neutron API service, so it is sufficient to
 neutron_server_tag: "2025.1"  # or "2024.1", "2024.2", "2025.2", depending on your OpenStack release
 ```
 
+:::warning
+Rolling tags exist only in the `kolla` namespace. In a deployment that uses an OSISM release namespace
+(`docker_namespace: kolla/release/<openstack_version>`), the tag override above resolves to an image that
+does not exist and the pull fails with `unknown: artifact ... not found`. The image parameter has to be
+overridden as well, so that this image is pulled from the `kolla` namespace:
+
+```yaml
+neutron_server_image: "registry.osism.tech/kolla/neutron-server"
+neutron_server_tag: "2025.1"  # or "2024.1", "2024.2", "2025.2", depending on your OpenStack release
+```
+
+`neutron_rpc_server_image`, `neutron_periodic_worker_image` and `neutron_ovn_maintenance_worker_image`
+default to `neutron_server_image` and are covered by this override. See
+[Rolling tags and release tags](../../guides/configuration-guide/openstack/index.md#rolling-tags-and-release-tags).
+:::
+
 The Neutron agent images (`neutron-openvswitch-agent`, `neutron-l3-agent`, and others) do not contain
 the affected code and do not need to be updated for this issue.
 

--- a/docs/appendix/security/ossa-2026-032.md
+++ b/docs/appendix/security/ossa-2026-032.md
@@ -195,7 +195,12 @@ for the Neutron container images via the following change:
 
 This change adds the patch for all four supported releases (2024.1, 2024.2, 2025.1, 2025.2).
 
-A fix will be included in upcoming OSISM releases that ship the patched Neutron container images.
+OSISM 10.2.0 is the first release that ships the patched Neutron container images. It pins the Kolla
+build `0.20260814.0`, in which `neutron-server` of the `kolla/release/2025.1` namespace is tagged
+`26.0.6.20260814` and carries Neutron 26.0.6, the version that contains the fix. Deployments on OSISM
+10.2.0 or later therefore obtain the fix by upgrading and do not need the image overrides described
+below. On OSISM 10.1.0 and earlier, which pin Kolla builds predating this advisory, the release
+namespace does not contain a patched image and the fix can only be obtained through the rolling tags.
 Consult the [OSISM Release Notes](../../release-notes/) for version information and availability.
 
 The vulnerable code path runs in the Neutron API service, so it is sufficient to override the

--- a/docs/guides/configuration-guide/openstack/index.md
+++ b/docs/guides/configuration-guide/openstack/index.md
@@ -26,6 +26,49 @@ The image tags can be set in the `environments/kolla/images.yml` file.
   barbican_worker_tag: "2023.1"
   ```
 
+### Rolling tags and release tags
+
+Kolla images are published in two namespaces on `registry.osism.tech`, and each namespace uses its own
+tagging scheme. The two schemes are not interchangeable — which tags you can use depends on the
+`docker_namespace` parameter set in `environments/kolla/configuration.yml`.
+
+| Namespace                           | Tag scheme                       | Example           | Meaning                                                               |
+|:------------------------------------|:---------------------------------|:------------------|:----------------------------------------------------------------------|
+| `kolla`                             | OpenStack release                | `2025.1`          | Rolling tag. Always points to the most recent build for that release. |
+| `kolla/release/<openstack_version>` | `<project version>.<build date>` | `26.0.4.20260615` | Immutable tag. Always points to exactly one build.                    |
+
+* **Rolling tags** exist only in the `kolla` namespace. A rolling tag such as `2025.1` is a moving
+  reference: it is republished whenever new images are built for OpenStack 2025.1 (Epoxy), so it always
+  resolves to the latest available build — including the latest security patches. It is a safe choice to
+  keep such a pin in place permanently, but the image it resolves to changes over time.
+
+* **Release tags** exist only in the `kolla/release/<openstack_version>` namespaces, which is what
+  deployments using an OSISM release consume (see
+  [New namespace for Kolla images](../../../release-notes/osism-10.md#new-namespace-for-kolla-images)).
+  These tags are immutable and are pinned per OSISM release, so a deployment always gets the exact same
+  images. The versions are shipped in the `osism/kolla-ansible` image and do not need to be configured.
+
+:::warning
+The `kolla/release/<openstack_version>` namespaces do **not** contain rolling tags. Setting
+`neutron_server_tag: "2025.1"` in a deployment with `docker_namespace: kolla/release/2025.1` therefore
+resolves to `registry.osism.tech/kolla/release/2025.1/neutron-server:2025.1`, which does not exist and
+fails with `unknown: artifact ... not found`.
+:::
+
+To use a rolling tag for a single image in a deployment that otherwise uses release tags, override the
+corresponding `*_image` parameter along with the tag, so that this one image is pulled from the `kolla`
+namespace:
+
+```yaml title="environments/kolla/images.yml"
+neutron_server_image: "registry.osism.tech/kolla/neutron-server"
+neutron_server_tag: "2025.1"
+```
+
+All images of a service that are derived from the same base image are covered by such an override. For
+Neutron, `neutron_rpc_server_image`, `neutron_periodic_worker_image` and
+`neutron_ovn_maintenance_worker_image` default to `neutron_server_image` and therefore do not need to be
+set individually.
+
 ## Endpoints
 
 ### Public endpoints

--- a/docs/guides/configuration-guide/openstack/index.md
+++ b/docs/guides/configuration-guide/openstack/index.md
@@ -69,6 +69,62 @@ Neutron, `neutron_rpc_server_image`, `neutron_periodic_worker_image` and
 `neutron_ovn_maintenance_worker_image` default to `neutron_server_image` and therefore do not need to be
 set individually.
 
+### Image parameters and tags of a specific OSISM version
+
+The [002-images-kolla.yml](https://github.com/osism/defaults/blob/main/all/002-images-kolla.yml) file
+linked at the beginning of this section points to the `main` branch of the
+[osism/defaults](https://github.com/osism/defaults) repository, which does not necessarily match the
+OSISM version in use. The parameters of a specific OSISM version are found through the
+[osism/release](https://github.com/osism/release) repository, which pins the version of every OSISM
+component. The `defaults_version` parameter in the `base.yml` of a release pins the tag of the
+`osism/defaults` repository, for OSISM 10.2.0 in
+[10.2.0/base.yml](https://github.com/osism/release/blob/main/10.2.0/base.yml).
+
+```yaml title="10.2.0/base.yml"
+manager_version: 10.2.0
+[...]
+defaults_version: v0.20260712.0
+```
+
+Following that tag, all image parameters available in OSISM 10.2.0 are listed in
+[all/002-images-kolla.yml at v0.20260712.0](https://github.com/osism/defaults/blob/v0.20260712.0/all/002-images-kolla.yml)
+for the OpenStack images and in
+[all/002-images-ceph.yml at v0.20260712.0](https://github.com/osism/defaults/blob/v0.20260712.0/all/002-images-ceph.yml)
+for the Ceph images.
+
+Which tags can be set for such a parameter depends on the tags published in the registry. They can be
+listed per image with `skopeo`, no credentials are required for this. The rolling tags of the Neutron API
+image in the `kolla` namespace:
+
+```console
+$ skopeo list-tags docker://registry.osism.tech/kolla/neutron-server
+{
+    "Repository": "registry.osism.tech/kolla/neutron-server",
+    "Tags": [
+        "2024.1",
+        "2024.2",
+        "2025.1",
+        "2025.2"
+    ]
+}
+```
+
+And the release tags of the same image in the `kolla/release/2025.1` namespace:
+
+```console
+$ skopeo list-tags docker://registry.osism.tech/kolla/release/2025.1/neutron-server
+{
+    "Repository": "registry.osism.tech/kolla/release/2025.1/neutron-server",
+    "Tags": [
+        "26.0.3.20251208",
+        "26.0.3.20260128",
+        "26.0.3.20260328",
+        "26.0.4.20260615",
+        "26.0.6.20260814"
+    ]
+}
+```
+
 ## Endpoints
 
 ### Public endpoints

--- a/docs/release-notes/osism-10.md
+++ b/docs/release-notes/osism-10.md
@@ -215,6 +215,17 @@ different OpenStack versions with a specific OSISM release.
 docker_namespace: kolla/release/2025.1
 ```
 
+The images in this namespace are tagged with an immutable `<project version>.<build date>` tag, for
+example `26.0.4.20260615`. The versions used are pinned per OSISM release and are shipped in the
+`osism/kolla-ansible` image, so they do not need to be configured.
+
+:::warning
+This namespace does not contain the rolling tags named after an OpenStack release, such as `2025.1`.
+Those exist only in the `kolla` namespace. Overriding a single image tag with a rolling tag therefore
+also requires overriding the image itself, see
+[Rolling tags and release tags](../guides/configuration-guide/openstack/index.md#rolling-tags-and-release-tags).
+:::
+
 ### New container registry
 
 Container images are no longer pushed to Quay.io and are only made available on our own


### PR DESCRIPTION
Documents the two Kolla image tag schemes, how to look up the image parameters
and tags of a specific OSISM version, and fixes the security advisory
remediation snippets that cannot be applied as written in a release-namespace
deployment.

Reported in https://github.com/osism/issues/issues/1430.

## Problem

The advisories tell operators to pin a rolling tag in
`environments/kolla/images.yml`:

```yaml
neutron_server_tag: "2025.1"
```

A deployment that follows the [OSISM 10 release
notes](https://osism.tech/docs/release-notes/osism-10#new-namespace-for-kolla-images)
and sets `docker_namespace: kolla/release/2025.1` resolves this to
`registry.osism.tech/kolla/release/2025.1/neutron-server:2025.1`, which does not
exist. The pull fails with `unknown: artifact ... not found`.

Both settings are individually correct and documented. The combination is not,
and nothing documented that. Nothing documented either where the tags that *can*
be set come from, or which image parameters exist in the OSISM version actually
deployed — the guide only linked `002-images-kolla.yml` at `main`.

## What was verified, and how

Everything factual below was checked against the registry or the source. Listing
it explicitly so nothing here has to be taken on trust.

**Method.** All registry facts come from `skopeo` — `skopeo list-tags`,
`skopeo inspect` and `skopeo copy` against `docker://registry.osism.tech/...`.
The Harbor token endpoint and `/v2/<repo>/tags/list` were **not** queried
directly with a bearer token. `skopeo` needs no credentials for these
repositories, is the tool the OSISM stack itself uses (`osism sync versions`),
and is therefore also what the added documentation shows as the example command,
so every listing below is reproducible with a single command.

**1. The two namespaces have disjoint tag sets.** `skopeo list-tags`, re-run on
2026-08-21:

| Repository                            | Tags returned                                                                                       |
|:--------------------------------------|:----------------------------------------------------------------------------------------------------|
| `kolla/neutron-server`                | `2024.1`, `2024.2`, `2025.1`, `2025.2`                                                              |
| `kolla/release/2025.1/neutron-server` | `26.0.3.20251208`, `26.0.3.20260128`, `26.0.3.20260328`, `26.0.4.20260615`, `26.0.6.20260814`       |

**2. Why they are disjoint.** `src/tag-images-with-the-version.py:221` in
`container-images-kolla` moves release builds into
`/kolla/release/<OPENSTACK_VERSION>/` using only the computed
`<version>.<build date>` tag. The rolling tag is never rewritten into that
namespace, so the split is by construction, not a publishing gap. Introduced in
osism/container-images-kolla#672.

**3. The rolling tag carries the OSSA-2026-032 fix.** `skopeo inspect
docker://registry.osism.tech/kolla/neutron-server:2025.1`: `created
2026-08-21T01:33:57Z`, `org.opencontainers.image.version = 26.0.6`,
`de.osism.version = latest`. The advisory names 26.0.6 as the fixed Epoxy
version.

**4. The release namespace now carries it too, from OSISM 10.2.0 on.**
`10.2.0/base.yml` in `osism/release` pinned Kolla `0.20260813.0` when the release
was prepared on 2026-08-13 and was bumped to `0.20260814.0` one day later by
[osism/release#2665](https://github.com/osism/release/pull/2665). Extracting
`/sbom.yml` from `osism/kolla-ansible:0.20260814.0` (`skopeo copy` into a `dir:`,
then the layer holding it) gives `versions.neutron: 26.0.6.20260814`, and
`skopeo inspect` on
`kolla/release/2025.1/neutron-server:26.0.6.20260814` reports
`org.opencontainers.image.version = 26.0.6`. OSISM 10.1.0 pins Kolla
`0.20260328.0`, from before the advisory, so it is unaffected by this and still
needs the override.

Worth flagging separately: the build `10.2.0` originally pinned,
`0.20260813.0`, contains **no neutron images at all** — its SBOM lists 120 images
and has no `neutron` key, where the complete builds list 133 and 60 versions.
With that SBOM, `kolla_neutron_version` falls back to `openstack_version`, so
neutron would have resolved to `kolla/release/2025.1/neutron-server:2025.1`,
a tag that does not exist. osism/release#2665 fixed that as well.

**5. Which images each recommended tag covers.** Read from
`osism/defaults/all/002-images-kolla.yml` at `main`: `keystone_tag` drives four
images (`keystone`, `keystone-fernet`, `keystone-ssh`, `httpd`), `nova_tag`
drives ten, `neutron_server_tag` and `nova_api_tag` one each.
`neutron_rpc_server_image`, `neutron_periodic_worker_image` and
`neutron_ovn_maintenance_worker_image` default to `neutron_server_image`.
`nova_libvirt_tag` derives from `kolla_nova_libvirt_version`, not `nova_tag`.

**6. The version lookup chain in the new section.** `10.2.0/base.yml` pins
`defaults_version: v0.20260712.0`; that tag exists in `osism/defaults` and holds
both `all/002-images-kolla.yml` and `all/002-images-ceph.yml`, so both links
resolve.

**7. Build and lint pass.** `yarn build` succeeds with `onBrokenLinks: 'throw'`;
the new anchor `id="rolling-tags-and-release-tags"` is generated and the inbound
links resolve. MegaLinter (documentation flavor: markdownlint,
markdown-table-formatter, codespell) reports no findings. The
`unsupported file type` SVG warnings in the build output are pre-existing and
unrelated.

## Changes

- **`configuration-guide/openstack/index.md`** — new `Rolling tags and release
  tags` section covering both schemes and the `*_image` override, which is the
  explanation of tag semantics asked for in the issue, plus a new `Image
  parameters and tags of a specific OSISM version` section: `osism/release` →
  `10.2.0/base.yml` → `defaults_version: v0.20260712.0` →
  `002-images-kolla.yml` / `002-images-ceph.yml` at that tag, with `skopeo
  list-tags` examples for the tags of both namespaces.
- **`release-notes/osism-10.md`** — states the tag scheme of the new namespace
  next to the `docker_namespace` change that introduced it, and warns that it
  holds no rolling tags.
- **OSSA-2026-001, -002, -005, -015, -022, -032** — each rolling-tag snippet
  gains the companion `*_image` override.
- **OSSA-2026-032** — additionally names OSISM 10.2.0 as the first release that
  ships the patched images, so release-namespace deployments can see that
  upgrading is now enough and the override is no longer required there.

The advisory snippets list *every* image the recommended tag covers, since a
partial override leaves the rest of the service pointing at a tag that does not
exist. That is why the `nova_tag` block in OSSA-2026-002 is ten lines.

## Judgment calls, for review

These are decisions rather than verified facts, so they are the parts most worth
a second opinion:

- **Placement in OSSA-2026-015** — its snippet is already followed by a
  trust-policy warning, so this one was added after it rather than between the
  snippet and that warning.
- **Remediation scope left untouched** — in OSSA-2026-002 the `qemu-img` path is
  reached in `nova-compute`, so the advisory's service-wide `nova_tag` is broader
  than strictly needed. Narrowing a published advisory's remediation seemed out
  of scope for a docs fix, so the scope was kept and made to work.
- **Wording of the `kolla` namespace as "rolling"** — taken from the advisories'
  own existing phrasing ("Using rolling tags, ...") rather than newly coined.
- **The overrides were kept in OSSA-2026-032** rather than replaced by "upgrade
  to 10.2.0", since they remain the only route for 10.1.0 and earlier.

## Not addressed here

The neutron-less Kolla build `0.20260813.0` and the fact that the `10.2.0`
release entry pointed at it for a day are noted above but not acted on; whether
that needs anything beyond osism/release#2665 is a maintainer call.

Separately, `osism sync versions --release <version>` looks broken: its defaults
build the SBOM reference as
`registry.osism.cloud/kolla/release/sbom:<kolla version>`, a repository whose
newest tag is `0.20251130.0`, while the current SBOM images live at
`registry.osism.tech/kolla/release/<openstack_version>/sbom:<kolla version>`.
That belongs in `python-osism`, not here, and is why the new documentation shows
`skopeo list-tags` rather than that command.

## Open questions from the issue

The reporter asked three questions that this PR answers in the docs, but which
are worth confirming as correct:

1. `docker_namespace: kolla/release/2025.1` is correct and should stay.
2. It does not need overriding wholesale, only per-image alongside a rolling tag,
   and from OSISM 10.2.0 on not even that for OSSA-2026-032.
3. Unpinned images are unaffected, because their versions come from the
   `versions.yml` rendered in the `osism/kolla-ansible` image from its baked-in
   SBOM.
