### PR TITLE
Fix version table. Epoxy has keystone 27.0.x.

### DIFF
--- a/docs/appendix/security/ossa-2026-015.md
+++ b/docs/appendix/security/ossa-2026-015.md
@@ -32,11 +32,13 @@ OIDC federation.
 
 | Keystone Version                         | Status                            |
 |:-----------------------------------------|:----------------------------------|
-| >= 14.0.0, < 28.0.0 (Caracal, Dalmatian) | Vulnerable — EOL, no official fix |
-| >= 28.0.0, < 28.0.2 (Epoxy)              | Vulnerable                        |
-| >= 28.0.2 (Epoxy)                        | Fixed (upstream)                  |
-| >= 29.0.0, < 29.0.2 (Flamingo)           | Vulnerable                        |
-| >= 29.0.2 (Flamingo)                     | Fixed (upstream)                  |
+| >= 14.0.0, < 27.0.0 (Caracal, Dalmatian) | Vulnerable — EOL, no official fix |
+| >= 27.0.0, < 27.0.2 (Epoxy)              | Vulnerable                        |
+| >= 27.0.2 (Epoxy)                        | Fixed (upstream)                  |
+| >= 28.0.0, < 28.0.2 (Flamingo)           | Vulnerable                        |
+| >= 28.0.2 (Flamingo)                     | Fixed (upstream)                  |
+| >= 29.0.0, < 29.0.2 (Gazpacho)           | Vulnerable                        |
+| >= 29.0.2 (Gazpacho)                     | Fixed (upstream)                  |
 
 Caracal (2024.1) and Dalmatian (2024.2) have reached end of life upstream. No official fixed
 release exists for either; the only fixes available are community-curated backports.


### PR DESCRIPTION
27.0.2 fixed it for Epoxy, 28.0.2 for Flamingo, 29.0.2 for Gazpacho. Correctly reflect this in the advisory.
Compare https://security.openstack.org/ossa/OSSA-2026-015.html and https://releases.openstack.org/ for reference.

Fixes #1057.