### PR TITLE
Add OSSA-2026-034 security advisory for Designate

### DIFF
--- a/docs/appendix/security/index.md
+++ b/docs/appendix/security/index.md
@@ -33,3 +33,4 @@ handling of security-related information.
 | [OSSA-2026-015](ossa-2026-015.md) | Credential delegation and authorization bypass issues | OpenStack Keystone           |
 | [OSSA-2026-022](ossa-2026-022.md) | Scheduler hint injection bypasses Placement claims    | OpenStack Nova               |
 | [OSSA-2026-032](ossa-2026-032.md) | Cross-project subnet mutation via subnetpool onboard  | OpenStack Neutron            |
+| [OSSA-2026-034](ossa-2026-034.md) | Cross-tenant DNS zone overlap and mDNS DoS            | OpenStack Designate          |

--- a/docs/appendix/security/ossa-2026-034.md
+++ b/docs/appendix/security/ossa-2026-034.md
@@ -1,0 +1,257 @@
+---
+sidebar_label: OSSA-2026-034
+---
+
+# OSSA-2026-034: Cross-tenant DNS zone overlap and mDNS DoS via pool scheduling
+
+| Property         | Value                                                                                                                                |
+|:-----------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| Date             | 2026-08-11                                                                                                                           |
+| CVE              | [CVE-2026-71193](https://www.cve.org/CVERecord?id=CVE-2026-71193), [CVE-2026-71194](https://www.cve.org/CVERecord?id=CVE-2026-71194) |
+| Severity         | High (multi-pool deployments only)                                                                                                   |
+| Affected Project | Designate                                                                                                                            |
+| Reporter         | Tore Anderson (Redpill Linpro AS), Omer Schwartz (Red Hat)                                                                           |
+
+## Summary
+
+Two related vulnerabilities were discovered in OpenStack Designate affecting deployments with
+multiple pools.
+
+Tore Anderson of Redpill Linpro AS reported that Designate does not enforce cross-pool zone
+ownership checks when a zone is scheduled to a non-default pool (CVE-2026-71193). The
+duplicate-zone, subzone, and superzone protections only ever considered zones within the same pool,
+so a tenant who can steer pool scheduling — for example via the attribute scheduler filter — can
+create an exact duplicate, a sub-zone, or a super-zone of another tenant's zone in a different
+pool, enabling DNS hijacking or denial of service.
+
+Independently, Omer Schwartz of Red Hat identified that the mDNS handler performs pool-blind record
+lookups (CVE-2026-71194). When zones with the same name exist in different pools, record and NOTIFY
+lookups become ambiguous and fail deterministically, breaking zone transfers to the backend
+nameservers for the colliding names — a deterministic denial of service.
+
+**Only deployments using multiple Designate pools are affected.** Upstream has not published a CVSS
+score for this issue. The severity rating above is OSISM's assessment for affected multi-pool
+deployments, where the issue is easy to exploit for any authenticated tenant and has high integrity
+and availability impact on the victim's DNS zones.
+
+## Affected Versions
+
+The upstream advisory states the affected ranges as `>=1.0.0 <20.0.2`, `==21.0.0` and `==22.0.0` —
+effectively every Designate release since the pool concept was introduced.
+
+| OpenStack Release      | Upstream Status                      | Fix in OSISM Images                                                                              |
+|:-----------------------|:-------------------------------------|:-------------------------------------------------------------------------------------------------|
+| Caracal (2024.1)       | Unmaintained, no upstream fix        | Community-curated backport ([PR #769](https://github.com/osism/container-images-kolla/pull/769)) |
+| Dalmatian (2024.2)     | End of life since 2026-04-29, no fix | Community-curated backport ([PR #769](https://github.com/osism/container-images-kolla/pull/769)) |
+| Epoxy (2025.1)         | Fixed in Designate 20.0.2            | Upstream fix via `stable/2025.1` branch                                                          |
+| Flamingo (2025.2)      | Fixed in Designate 21.0.1            | Upstream fix via `stable/2025.2` branch                                                          |
+| Gazpacho (2026.1)      | Fixed in Designate 22.0.1            | Not shipped by OSISM yet                                                                         |
+| Hibiscus (2026.2, dev) | Fix merged on master                 | Not shipped by OSISM yet                                                                         |
+
+Caracal (2024.1) is unmaintained and Dalmatian (2024.2) reached end of life upstream; neither will
+receive an official fixed release. For exactly these two releases OSISM provides the fix as
+community-curated backports, shipped as downstream patches in the Designate container images.
+
+For Epoxy (2025.1) and Flamingo (2025.2) the OSISM container images build Designate from the
+upstream stable branches, which contain the fix as of Designate 20.0.2 and 21.0.1. Rebuilt images
+include the fix without additional downstream patches.
+
+Patched container images are available for all four supported OpenStack releases.
+
+## Impact on OSISM
+
+Designate is an optional service in OSISM (`enable_designate` in
+`environments/kolla/configuration.yml`). Deployments without Designate are not affected.
+
+A default OSISM deployment configures **exactly one Designate pool** (the default pool with the
+BIND backend) and leaves the pool scheduler at its default configuration. The default scheduler
+filter `default_pool` always assigns the default pool and ignores tenant-supplied zone attributes.
+In this configuration there is no second pool to schedule a colliding zone into, so **default OSISM
+deployments are not exploitable**.
+
+Affected are deployments where the operator has configured **additional pools** (via a custom pool
+definition and `designate-manage pool update`). In multi-pool deployments:
+
+- The zone ownership bypass (CVE-2026-71193) is directly exploitable by any authenticated tenant if
+  the `attribute` scheduler filter (or another filter honoring tenant-supplied zone attributes) is
+  enabled, because the tenant can deliberately target a pool other than the one holding the
+  victim's zone.
+- The mDNS denial of service (CVE-2026-71194) triggers whenever zones with colliding names exist in
+  different pools, regardless of how they came to exist.
+
+### How to Check if You Are Affected
+
+#### Check Whether Designate Is Deployed
+
+```bash
+docker ps --format '{{.Names}}' | grep ^designate
+```
+
+No output means Designate is not deployed and the deployment is not affected.
+
+#### Check the Running Designate Version
+
+```bash
+docker exec designate_central pip show designate | grep ^Version
+```
+
+If the version is below the fixed version for your release (see the table above) and you have not
+deployed an OSISM container image that includes the fix, the code in your deployment is vulnerable.
+Whether it is exploitable depends on the pool configuration checked next.
+
+#### Check the Number of Configured Pools
+
+```bash
+docker exec designate_central designate-manage pool show_config --all_pools
+```
+
+If exactly one pool is configured — the OSISM default — the deployment is not exploitable. More
+than one pool means the deployment is affected. Note that this command is only available starting
+with 2025.1, for older releases you need to check the definitions in
+`/etc/kolla/designate-worker/pools.yaml`.
+
+#### Check the Scheduler Configuration (Multi-Pool Only)
+
+```bash
+docker exec designate_central grep scheduler_filters /etc/designate/designate.conf
+```
+
+No output means the default `default_pool` filter is active and tenants cannot steer pool
+scheduling. If the `attribute` filter is enabled, tenants can target arbitrary pools and the
+ownership bypass is directly exploitable.
+
+#### Audit Existing Zones for Cross-Tenant Collisions (Multi-Pool Only)
+
+Zones colliding across pools may have been created before the fix was applied. Duplicate zone
+names can be found as follows:
+
+```bash
+openstack --os-cloud admin zone list --all-projects -f value -c name | sort | uniq -d
+```
+
+Any name returned here exists more than once. Verify with `openstack zone show` whether the
+duplicates belong to different projects. Sub-zone and super-zone overlaps require a manual review
+of the zone list; upstream has announced a detection tool as a separate public patch.
+
+## Vulnerability Details
+
+### CVE-2026-71193 — Cross-tenant zone overlap via pool scheduling
+
+When a zone is created, Designate's central service protects existing zones through three checks:
+a duplicate-name check, a subzone check (the new zone must not be a child of another tenant's
+zone), and a superzone check (the new zone must not be a parent of another tenant's zone). All
+three checks were scoped to a single pool. By steering the pool scheduler to a different pool —
+for example through tenant-supplied zone attributes evaluated by the `attribute` filter — a tenant
+could bypass all three protections against a zone living in another pool and create an exact
+duplicate, sub-zone, or super-zone of another tenant's zone.
+
+Depending on which pool's nameservers are queried by resolvers, the colliding zone allows the
+attacker to serve their own DNS data for the victim's names (DNS hijack) or to disrupt the
+victim's DNS service.
+
+The fix adds `_check_zone_ownership_conflicts()` to the central service, called before pool
+scheduling takes place. It searches for exact-name, subzone, and superzone conflicts across all
+pools with an elevated all-projects context and rejects the request only when the conflicting zone
+belongs to a different tenant. Same-tenant use of identical or overlapping names across pools
+(split-horizon setups, pool migrations) remains allowed.
+
+### CVE-2026-71194 — Deterministic mDNS denial of service through pool-blind lookups
+
+The mDNS service, which serves zone transfers (AXFR) to the backend nameservers and processes
+NOTIFY messages, looked up recordsets and zones by name only, without scoping the lookup to a
+pool. When zones with the same name exist in different pools, these lookups find multiple results
+and fail — mDNS answers with REFUSED. Zone transfers for the colliding names break
+deterministically, and the affected zones become stuck. A tenant able to create a colliding zone
+(see CVE-2026-71193) could deliberately trigger this against another tenant's zone.
+
+The fix scopes the mDNS lookups by pool: record queries resolve the zone first, walking from the
+query name up through its ancestors and scoping each candidate by the pool derived from the TSIG
+key on the request (or the default pool), with no unscoped fallback remaining. NOTIFY handling,
+which has no TSIG relationship to scope by, fetches every zone matching the name and disambiguates
+using the trust check it already performs — whether the sending IP is a configured master for that
+zone.
+
+### Prerequisite Changes
+
+The upstream fix consists of three changes that OSISM ships together in the patched images:
+
+1. **Fix mDNS record query pool scoping for split-horizon DNS**
+   ([Bug #2142581](https://bugs.launchpad.net/designate/+bug/2142581)) — introduces TSIG-based
+   pool scoping in the mDNS record query path.
+2. **Require TSIG keys for zones in non-default pools**
+   ([Bug #2008693](https://bugs.launchpad.net/designate/+bug/2008693)) — zone creation and pool
+   moves into a non-default pool now fail fast unless the target pool has a pool-scoped TSIG key
+   configured, making the TSIG-based pool scoping dependable.
+3. **Fix cross-tenant/cross-pool zone ownership bypass**
+   ([Bug #2160533](https://bugs.launchpad.net/designate/+bug/2160533)) — the actual fix for both
+   CVEs as described above.
+
+:::warning
+
+Behavior change for multi-pool deployments: after the fix, every non-default pool must have a
+pool-scoped TSIG key configured. Creating a zone in — or moving a zone into — a non-default pool
+without one is rejected. Single-pool deployments (the OSISM default) are not affected by this
+change.
+
+:::
+
+## Remediation
+
+### For OSISM Releases
+
+For the OpenStack releases 2024.1 (Caracal) and 2024.2 (Dalmatian), which receive no official
+upstream fix, OSISM provides the fix as downstream patches for the Designate container images via
+the following change:
+
+- [container-images-kolla commit cefc3e0](https://github.com/osism/container-images-kolla/commit/cefc3e01eb2a898e2587b8decc3df03bc9272ce1)
+  ([PR #769](https://github.com/osism/container-images-kolla/pull/769))
+
+For 2025.1 (Epoxy) and 2025.2 (Flamingo), the container images build Designate from the upstream
+stable branches, which contain the fix as of Designate 20.0.2 and 21.0.1. Rebuilt images include
+the fix automatically.
+
+A fix will be included in upcoming OSISM releases that ship the patched Designate container
+images. Consult the [OSISM Release Notes](../../release-notes/) for version information and
+availability.
+
+The affected code runs in the `designate-central` and `designate-mdns` services. Using rolling
+tags, the simplest approach is to override all Designate container images in
+`environments/kolla/images.yml`:
+
+```yaml
+designate_tag: "2024.1"  # or "2024.2", "2025.1", "2025.2", depending on your OpenStack release
+```
+
+### Mitigation
+
+Deployments with a single pool — the OSISM default — are not exploitable; updating the images at
+the next regular maintenance is sufficient.
+
+For multi-pool deployments, until the patched container image is deployed:
+
+1. If the `attribute` scheduler filter is enabled and attribute-based pool targeting is not
+   strictly required by your tenants, remove it from `scheduler_filters` in the Designate
+   configuration so that tenants can no longer steer pool scheduling. Note that this changes how
+   new zones are assigned to pools.
+2. Audit existing zones for cross-tenant duplicates and overlaps (see
+   [How to Check if You Are Affected](#audit-existing-zones-for-cross-tenant-collisions-multi-pool-only)).
+   Collisions created before the fix are not repaired by the patch and must be resolved manually.
+3. Ensure every non-default pool has a pool-scoped TSIG key configured. This is required by the
+   patched version anyway and is a prerequisite for reliable pool scoping in mDNS.
+4. Monitor the `designate-mdns` logs for REFUSED responses on record queries and NOTIFY messages,
+   which indicate colliding zone names across pools.
+
+## References
+
+- [OSSA-2026-034 Advisory](https://security.openstack.org/ossa/OSSA-2026-034.html)
+- [OSISM Fix (container-images-kolla commit cefc3e0)](https://github.com/osism/container-images-kolla/commit/cefc3e01eb2a898e2587b8decc3df03bc9272ce1)
+- [OSISM Fix (container-images-kolla PR #769)](https://github.com/osism/container-images-kolla/pull/769)
+- [OpenDev Review (Fix - Epoxy)](https://review.opendev.org/1000475)
+- [OpenDev Review (Fix - Flamingo)](https://review.opendev.org/1000474)
+- [OpenDev Review (Fix - Gazpacho)](https://review.opendev.org/1000473)
+- [OpenDev Review (Fix - Hibiscus)](https://review.opendev.org/1000471)
+- [Launchpad Bug #2160533](https://bugs.launchpad.net/designate/+bug/2160533)
+- [Launchpad Bug #2142581](https://bugs.launchpad.net/designate/+bug/2142581)
+- [Launchpad Bug #2008693](https://bugs.launchpad.net/designate/+bug/2008693)
+- [CVE-2026-71193](https://www.cve.org/CVERecord?id=CVE-2026-71193)
+- [CVE-2026-71194](https://www.cve.org/CVERecord?id=CVE-2026-71194)


### PR DESCRIPTION
Document the cross-tenant DNS zone overlap and mDNS DoS in Designate (CVE-2026-71193, CVE-2026-71194) in the security appendix.

- Zone ownership checks (duplicate, subzone, superzone) and mDNS lookups were scoped to a single pool; only multi-pool deployments are exploitable, default OSISM deployments (single pool, `default_pool` scheduler filter) are not.
- Upstream fixed Epoxy (20.0.2), Flamingo (21.0.1), and Gazpacho (22.0.1); the OSISM images for Epoxy/Flamingo pick these up via the stable branches. For the EOL releases Caracal and Dalmatian OSISM ships community-curated backports via osism/container-images-kolla#769.
- Includes check instructions (pool count, scheduler filters, zone collision audit), the TSIG behavior change for non-default pools, and mitigations for multi-pool deployments.

References:
- https://security.openstack.org/ossa/OSSA-2026-034.html
- https://github.com/osism/container-images-kolla/pull/769