### PR TITLE
Drop the documentation branches for end of life releases

### DIFF
--- a/docs/guides/configuration-guide/configuration-repository.md
+++ b/docs/guides/configuration-guide/configuration-repository.md
@@ -72,7 +72,7 @@ listed there will be queried during the execution of Cookiecutter.
    this is always set to the latest stable version.
 
    ```yaml
-   manager_version [7.0.4]: latest
+   manager_version [10.2.0]: latest
    ```
 
    If the `manager_version` parameter is set to `latest` it is also possible to explicitly
@@ -81,7 +81,7 @@ listed there will be queried during the execution of Cookiecutter.
    ```console
    [1/18] with_ceph (1):
    [2/18] ceph_network(192.168.16.0/20):
-   [3/18] ceph_version (quincy):
+   [3/18] ceph_version (reef):
    [4/18] domain (osism.xyz):
    [5/18] fqdn_external (api.osism.xyz):
    [6/18] fqdn_internal (api-int.osism.xyz):
@@ -92,10 +92,10 @@ listed there will be queried during the execution of Cookiecutter.
    [11/18] git_version (main):
    [12/18] ip_external (192.168.16.254):
    [13/18] ip_internal (192.168.16.9):
-   [14/18] manager_version (7.0.4):
+   [14/18] manager_version (10.2.0):
    [15/18] name_server (149.112.112.112):
    [16/18] ntp_server (de.pool.ntp.org):
-   [17/18] openstack_version (2023.2):
+   [17/18] openstack_version (2025.1):
    [18/18] project_name (configuration):
    ```
 
@@ -411,7 +411,7 @@ If you want to use the latest version, this is done using the `manager_version` 
 this is always set to the latest stable version.
 
 ```yaml
-manager_version [7.0.0]: latest
+manager_version [10.2.0]: latest
 ```
 
 If the `manager_version` parameter is set to `latest` it is also possible to explicitly
@@ -422,7 +422,7 @@ set the `openstack_version` and the `ceph_version` explicitly.
 | Parameter           | Description                                                                                                                                | Default                                  |
 |:--------------------|:-------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------|
 | `ceph_network`      | Address range for Ceph's network                                                                                                           | `192.168.16.0/20`                        |
-| `ceph_version`      | The version of Ceph. When using a stable OSISM release (`manager_version != latest`), this value is ignored                                | `quincy`                                 |
+| `ceph_version`      | The version of Ceph. When using a stable OSISM release (`manager_version != latest`), this value is ignored                                | `reef`                                   |
 | `domain`            | The domain used by hostnames                                                                                                               | `osism.xyz`                              |
 | `fqdn_external`     | External API FQDN                                                                                                                          | `api.osism.xyz`                          |
 | `fqdn_internal`     | Internal API FQDN                                                                                                                          | `api-int.osism.xyz`                      |
@@ -433,10 +433,10 @@ set the `openstack_version` and the `ceph_version` explicitly.
 | `git_version`       | Git branch name                                                                                                                            | `main`                                   |
 | `ip_external`       | The external IP address of the API (resolves to `fqdn_external`)                                                                           | `192.168.16.254`                         |
 | `ip_internal`       | The internal IP address of the API (resolves to `fqdn_internal`)                                                                           | `192.168.16.9`                           |
-| `manager_version`   | The version of OSISM. An overview of available OSISM releases can be found on the [release page](https://osism.tech/docs/release-notes/)   | `7.0.4`                                  |
+| `manager_version`   | The version of OSISM. An overview of available OSISM releases can be found on the [release page](https://osism.tech/docs/release-notes/)   | `10.2.0`                                 |
 | `name_server`       | Nameserver. Only one nameserver is set here because the query of multiple values in Cookiecutter is weird. Add more nameservers afterward. | `149.112.112.112`                        |
 | `ntp_server`        | NTP server. Only one NTP server is set here because the query of multiple values in Cookiecutter is weird. Add more NTP servers afterward. | `de.pool.ntp.org`                        |
-| `openstack_version` | The version of OpenStack. When using a stable OSISM release (`manager_version != latest`), this value is ignored                           | `2023.2`                                 |
+| `openstack_version` | The version of OpenStack. When using a stable OSISM release (`manager_version != latest`), this value is ignored                           | `2025.1`                                 |
 | `project_name`      | Name of the configuration repository directory                                                                                             | `configuration`                          |
 | `with_ceph`         | `1` to use Ceph, `0` to not use Ceph                                                                                                       | `1`                                      |
 

--- a/docs/guides/configuration-guide/loadbalancer.md
+++ b/docs/guides/configuration-guide/loadbalancer.md
@@ -175,12 +175,6 @@ For more details about this topic, we recommend the [official kolla-ansible docu
 
 ## Second Loadbalancer
 
-:::info
-
-This feature is available from OSISM 7.0.5.
-
-:::
-
 With OSISM, it is possible to manage any number of independent loadbalancers via a single OSISM
 manager service using sub-environments. A sub environment is basically nothing more than another directory
 below the `environments` directory of the configuration repository with a special name.

--- a/docs/guides/configuration-guide/manager.mdx
+++ b/docs/guides/configuration-guide/manager.mdx
@@ -2,8 +2,6 @@
 sidebar_label: Manager
 sidebar_position: 15
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Manager
 
@@ -31,33 +29,9 @@ In the example, OSISM release 7.0.5 is used.
 
 3. Sync the image versions in the configuration repository.
 
-   <Tabs>
-   <TabItem value="osism-7" label="OSISM >= 7.0.0">
    ```bash
    make sync
    ```
-   </TabItem>
-   <TabItem value="osism-6" label="OSISM < 7.0.0">
-   If Gilt is not installed via the `requirements.txt` of the manager environment it is
-   important to use a version smaller v2. The v2 of Gilt is not yet usable.
-   ```bash
-   python3 -m venv venv
-   source venv/bin/activate
-   pip install -r requirements.txt
-     gilt overlay && gilt overlay
-   ```
-
-   Optionally, this is normally not necessary, it is possible to reference a specific tag of the
-   [osism/generics](https://github.com/osism/generics) repository. To do this, first
-   check which version of osism/generics is used in a particular release. The version is
-   defined in `generics_version` in the `base.yml` file in the `osism/release` repository. For OSISM 6.0.0,
-   for example, this is version [v0.20230919.0](https://github.com/osism/release/blob/main/6.0.0/base.yml#L6).
-   This version is then added to the file `gilt.yml` in the configuration repository instead of
-   `main` at `version`. This change must be made again after each execution of `gilt overlay` as
-   it is overwritten by the call of `gilt overlay`. This cannot be realized differently in the
-   current implementation of [Gilt](https://github.com/retr0h/gilt).
-   </TabItem>
-   </Tabs>
 
 4. Commit and push changes in the configuration repository. Since everyone here has their own
    workflows for changes to the configuration repository, only a generic example for Git.

--- a/docs/guides/configuration-guide/manager.mdx
+++ b/docs/guides/configuration-guide/manager.mdx
@@ -10,16 +10,16 @@ sidebar_position: 15
 :::warning
 
 Always read the [release notes](https://osism.tech/docs/release-notes/) first to learn what has changed and what
-adjustments are necessary. Read the release notes even if you are only updating from e.g. 7.0.2 to 7.0.5.
+adjustments are necessary. Read the release notes even if you are only updating from e.g. 10.0.0 to 10.1.0.
 
 :::
 
-In the example, OSISM release 7.0.5 is used.
+In the example, OSISM release 10.1.0 is used.
 
 1. Set the new manager version in the configuration repository.
 
    ```bash
-   MANAGER_VERSION="7.0.5"
+   MANAGER_VERSION="10.1.0"
    sed -i "~s,^manager_version:.*\$,manager_version: ${MANAGER_VERSION}," environments/manager/configuration.yml
    ```
 

--- a/docs/guides/configuration-guide/network.md
+++ b/docs/guides/configuration-guide/network.md
@@ -7,7 +7,7 @@ sidebar_position: 15
 
 ## Netplan
 
-```yaml title="Since OSISM 6.1.0, the default network type is a netplan and no longer needs to be set explicitly"
+```yaml title="The default network type is a netplan and does not need to be set explicitly"
 network_type: netplan
 ```
 

--- a/docs/guides/configuration-guide/openstack/horizon.md
+++ b/docs/guides/configuration-guide/openstack/horizon.md
@@ -1,8 +1,6 @@
 ---
 sidebar_label: Horizon
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Horizon
 
@@ -30,8 +28,6 @@ By default, only the `openrc` file is offered for download in Horizon. It makes 
 `clouds.yaml` as a download. To do this, the menu is customized. The change can be deployed with
 `osism apply -a reconfigure horizon`.
 
-<Tabs>
-<TabItem value="osism-8" label="OSISM >= 8.0.0">
 ```yaml title="environments/kolla/files/overlays/horizon/_9999-custom-settings.py"
 SHOW_KEYSTONE_V2_RC = False
 USER_MENU_LINKS = [
@@ -47,25 +43,6 @@ USER_MENU_LINKS = [
    }
 ]
 ```
-</TabItem>
-<TabItem value="osism-7" label="OSISM < 8.0.0">
-```yaml title="environments/kolla/files/overlays/horizon/custom_local_settings"
-SHOW_KEYSTONE_V2_RC = False
-USER_MENU_LINKS = [
-  {'name': _('OpenStack clouds.yml File'),
-   'icon_classes': ['fa-download', ],
-   'url': 'horizon:project:api_access:clouds.yaml',
-   'external': False,
-   },
-  {'name': _('OpenStack RC File v3'),
-   'icon_classes': ['fa-download', ],
-   'url': 'horizon:project:api_access:openrc',
-   'external': False,
-   }
-]
-```
-</TabItem>
-</Tabs>
 
 ## Custom themes
 
@@ -86,15 +63,6 @@ USER_MENU_LINKS = [
 
 3. If the custom theme should be the default then add the `DEFAULT_THEME` parameter.
 
-   <Tabs>
-   <TabItem value="osism-8" label="OSISM >= 8.0.0">
    ```python title="environments/kolla/files/overlays/horizon/_9999-custom-settings.py"
    DEFAULT_THEME = 'custom_theme'
    ```
-   </TabItem>
-   <TabItem value="osism-7" label="OSISM < 8.0.0">
-   ```python title="environments/kolla/files/overlays/horizon/custom_local_settings"
-   DEFAULT_THEME = 'custom_theme'
-   ```
-   </TabItem>
-   </Tabs>

--- a/docs/guides/configuration-guide/openstack/index.md
+++ b/docs/guides/configuration-guide/openstack/index.md
@@ -93,8 +93,7 @@ placement_public_endpoint: https://placement.services.a.regiocloud.tech
 ```
 
 Since we bind the `name_based_external_front` frontend to the same ports as the
-`horizon_external_front`, the external Horizon frontend must be disabled. This is
-only possible as of OSISM 7.0.6.
+`horizon_external_front`, the external Horizon frontend must be disabled.
 
 ```yaml title="environments/kolla/configuration.yml"
 haproxy_enable_horizon_external: false

--- a/docs/guides/configuration-guide/openstack/nova.md
+++ b/docs/guides/configuration-guide/openstack/nova.md
@@ -240,25 +240,9 @@ As Ceph is still used as the storage backend for Glance and Cinder, the image ty
 set to `raw`. To allow to download and cache images from Ceph via rbd rather than the
 Glance API via http  `enable_rbd_download` is set to `true`.
 
-Parameters must also be added in the inventory. This differs depending on the OSISM
-version used.
-
-Up to OSISM 6 it looks like this:
-
-In the inventory, the parameter `nova_instance_datadir_volume`
-is added in the section for the `kolla` environment.
-
-```yaml title="inventory/host_vars/testbed-node-0.yml"
-##########################################################
-# kolla
-
-nova_instance_datadir_volume: /var/lib/nova
-```
-
-Starting with OSISM 7, it looks like this:
-
-In the inventory, the parameters `nova_instance_datadir_volume` and `nova_backend`,
-are added in the section for the `kolla` environment.
+Parameters must also be added in the inventory. The parameters
+`nova_instance_datadir_volume` and `nova_backend` are added in the section for the
+`kolla` environment.
 
 ```yaml title="inventory/host_vars/testbed-node-0.yml"
 ##########################################################

--- a/docs/guides/deploy-guide/services/ceph/index.mdx
+++ b/docs/guides/deploy-guide/services/ceph/index.mdx
@@ -3,8 +3,6 @@ sidebar_label: Ceph
 sidebar_key: deploy-guide-ceph
 sidebar_position: 50
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 # Ceph
 
@@ -50,7 +48,7 @@ OSD devices must be completed. The steps that are required for this can be found
      osism apply ceph-osds
      ```
 
-   * Generate pools and keys. This step is only necessary for OSISM >= 7.0.0.
+   * Generate pools and keys.
 
      ```bash
      osism apply ceph-pools
@@ -68,8 +66,6 @@ OSD devices must be completed. The steps that are required for this can be found
    This speeds up the entire process and avoids unnecessary restarts of individual
    services.
 
-   <Tabs>
-   <TabItem value="osism-7" label="OSISM >= 7.0.0">
    ```bash
    osism apply ceph
    ```
@@ -79,13 +75,6 @@ OSD devices must be completed. The steps that are required for this can be found
    ```bash
    osism apply ceph-pools
    ```
-   </TabItem>
-   <TabItem value="osism-6" label="OSISM < 7.0.0">
-   ```bash
-   osism apply ceph-base
-   ```
-   </TabItem>
-   </Tabs>
 
    :::
 

--- a/docs/guides/deploy-guide/services/ceph/index.mdx
+++ b/docs/guides/deploy-guide/services/ceph/index.mdx
@@ -167,10 +167,6 @@ Step 3 is then performed **later after** the OpenStack Keystone service has been
 
 ### Avoiding service restarts
 
-:::info
-Usable from OSISM 7.0.3 onwards.
-:::
-
 If Ceph services are deployed sequentially, this can lead to unwanted service restarts.
 This can also happen if, for example, new OSDs are added later or a new control node is
 added.
@@ -194,10 +190,6 @@ ceph_handler_rgws_restart
 ```
 
 ### Throttling service restarts
-
-:::info
-Usable from OSISM 7.0.3 onwards.
-:::
 
 Sometimes service restarts are required. For example, if the configuration has changed
 or if new OSDs have been added. It may be necessary and useful to only restart the

--- a/docs/guides/deploy-guide/services/kubernetes.md
+++ b/docs/guides/deploy-guide/services/kubernetes.md
@@ -7,9 +7,9 @@ sidebar_position: 12
 
 :::info
 
-As of OSISM 7, it is possible to create a Kubernetes cluster on all nodes.
-At the moment, this is still optional. In the future, it will be necessary
-to deploy this Kubernetes cluster.
+It is possible to create a Kubernetes cluster on all nodes. At the moment,
+this is still optional. In the future, it will be necessary to deploy this
+Kubernetes cluster.
 
 :::
 

--- a/docs/guides/migration-guide/cephadm/index.md
+++ b/docs/guides/migration-guide/cephadm/index.md
@@ -47,8 +47,8 @@ For the full upstream documentation, refer to
 * A running Ceph cluster deployed with ceph-ansible via OSISM.
 * All Ceph daemons are healthy (`ceph -s` reports `HEALTH_OK` or only expected warnings).
 * SSH access from the OSISM manager node to all Ceph nodes (required by cephadm for orchestration).
-* The Ceph cluster must be running at least Ceph Octopus (15.2.x) or later. Clusters on
-  OSISM 7 or later already meet this requirement.
+* The Ceph cluster must be running at least Ceph Octopus (15.2.x) or later. Clusters
+  deployed with a supported OSISM release already meet this requirement.
 * Python 3 and `lvm2` must be installed on all Ceph nodes (these are typically already present).
 
 TODO: Consider replacing the manual prerequisite checks with an `osism apply ready-for-cephadm`

--- a/docs/guides/operations-guide/infrastructure.md
+++ b/docs/guides/operations-guide/infrastructure.md
@@ -7,15 +7,7 @@ sidebar_label: Infrastructure
 ## Loadbalancer
 
 For the `manage-loadbalancer` play to work, the internal control socket
-of the HAProxy service must be set to admin level. As of OSISM 7.0.6 this
-is the default. Before this, the parameter `haproxy_socket_level_admin` must
-be added to the configuration repository and then a reconfigure
-(`osism apply -a reconfigure loadbalancer`) must be done for the loadbalancer
-service.
-
-```yaml title="environments/kolla/configuration.yml"
-haproxy_socket_level_admin: "yes"
-```
+of the HAProxy service must be set to admin level. This is the default.
 
 You can check in the HAProxy configuration whether the control socket is
 configured correctly.
@@ -76,7 +68,7 @@ of MariaDB. For more details about backups, you can use the official
   osism apply mariadb_backup
   ```
 
-* Create a incremental backup (supported as of OSISM 7.0.6)
+* Create a incremental backup
 
   ```bash
   osism apply mariadb_backup -e mariadb_backup_type=incremental

--- a/docs/guides/operations-guide/openstack/index.md
+++ b/docs/guides/operations-guide/openstack/index.md
@@ -7,7 +7,7 @@ sidebar_key: operations-guide-openstack
 
 ## Create an external network
 
-The play `network-external` is available and usable as of OSISM 7.0.6.
+The play `network-external` is used to create an external network.
 
 ```bash
 osism apply network-external

--- a/docs/testbed/deployment.mdx
+++ b/docs/testbed/deployment.mdx
@@ -87,7 +87,7 @@ This section describes step by step how to deploy the OSISM Testbed.
    </TabItem>
    <TabItem value="testbed-deploy-stable" label="Deploy a stable version">
    ```bash
-   make ENVIRONMENT=regiocloud VERSION_MANAGER=8.0.1 manager
+   make ENVIRONMENT=regiocloud VERSION_MANAGER=10.1.0 manager
    ```
    </TabItem>
    </Tabs>


### PR DESCRIPTION
Follows [`ab65fe95f5`](https://github.com/osism/osism.github.io/commit/ab65fe95f5) (`manager: drop the pre-7 gilt instructions`) and applies the same rule across the docs: where a page branches between instructions for different OSISM releases, the branch goes once every release it serves is end of life, and the surviving branch becomes plain text.

The cut line here is OSISM 7 and older. **OSISM 8 content is kept for now**, so the `OSISM >= 9.0.0` / `< 9.0.0` tabs in the Ceph configuration guide stay untouched — their lower branch is the OSISM 8 RGW configuration.

Three commits:

1. **Version tabs** — the gilt tab in the manager configuration guide, the `osism apply ceph-base` tab in the Ceph deploy guide, and both `custom_local_settings` tabs in the Horizon configuration guide. With the last tab gone from each page, the `Tabs`/`TabItem` imports go too.
2. **Prose version gates** — nine files that qualified a feature with the release that introduced it ("as of OSISM 7.0.6", "Usable from OSISM 7.0.3 onwards", …). Every release still in use satisfies them.
3. **Version examples** — the manager configuration guide and the testbed deployment guide now use 10.1.0, matching the manager upgrade guide.

Two spots needed more than a qualifier removal:

* `operations-guide/infrastructure.md` also explained how to set `haproxy_socket_level_admin` and reconfigure the loadbalancer for releases before OSISM 7.0.6. Since the admin level is the default, the parameter and its example went with the sentence.
* `configuration-guide/openstack/nova.md` showed the inventory `host_vars` twice, once for OSISM 6 without `nova_backend` and once for OSISM 7 with it. Only the variant with `nova_backend` remains.

> [!IMPORTANT]
> **Merge order.** `configuration-guide/configuration-repository.md` does not suggest a version, it transcribes the Cookiecutter prompts and defaults. Those values are updated to `manager_version` 10.2.0, `openstack_version` 2025.1 and `ceph_version` reef, which is what osism/cfg-cookiecutter#870 sets. That pull request is a draft until the 10.2.0 release is complete, so it should merge first — otherwise these three values describe a Cookiecutter default that does not exist yet.

`developer-guide/releases.md` and `testbed/appendix.mdx` are left alone — their versions are examples of the release process itself.

Verified with `yarn build` (no MDX or sidebar warnings) and MegaLinter's markdownlint over all changed files; the parameter table also passes `markdown-table-formatter --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)