### PR TITLE
Replace the Quay.io references with the OSISM registry

### DIFF
--- a/docs/guides/operations-guide/openstack/index.md
+++ b/docs/guides/operations-guide/openstack/index.md
@@ -143,22 +143,22 @@ if you have not deployed the optional OpenStack telemetry service.
 
 ```console
 $ docker ps
-CONTAINER ID   IMAGE                                                      COMMAND                  CREATED         STATUS                   PORTS                         NAMES
-559e5176695c   quay.io/osism/nova-compute:27.1.1.20230919                 "dumb-init --single-…"   5 minutes ago   Up 5 minutes (healthy)                                 nova_compute
-31248d71ab7d   quay.io/osism/nova-libvirt:8.0.0.20230919                  "dumb-init --single-…"   6 minutes ago   Up 6 minutes (healthy)                                 nova_libvirt
-9292030d706c   quay.io/osism/nova-ssh:27.1.1.20230919                     "dumb-init --single-…"   6 minutes ago   Up 6 minutes (healthy)                                 nova_ssh
-fda4b6fb30c8   quay.io/osism/neutron-metadata-agent:22.0.3.20230919       "dumb-init --single-…"   2 hours ago     Up 2 hours (healthy)                                   neutron_ovn_metadata_agent
-0e3ec450b668   quay.io/osism/ceilometer-compute:20.0.1.20230919           "dumb-init --single-…"   6 hours ago     Up 6 hours (healthy)                                   ceilometer_compute
-25ff9702e0e5   quay.io/osism/prometheus-libvirt-exporter:6.0.0.20230919   "dumb-init --single-…"   6 hours ago     Up 6 hours                                             prometheus_libvirt_exporter
-1bff2e29923b   quay.io/osism/prometheus-cadvisor:0.45.0.20230919          "dumb-init --single-…"   6 hours ago     Up 6 hours                                             prometheus_cadvisor
-602832daf237   quay.io/osism/prometheus-node-exporter:1.4.0.20230919      "dumb-init --single-…"   6 hours ago     Up 6 hours                                             prometheus_node_exporter
-d4de2f32cdf8   quay.io/osism/ovn-controller:23.6.1.20230919               "dumb-init --single-…"   6 hours ago     Up 6 hours                                             ovn_controller
-3bf43ae5a94f   quay.io/osism/openvswitch-vswitchd:3.1.2.20230919          "dumb-init --single-…"   7 hours ago     Up 7 hours (healthy)                                   openvswitch_vswitchd
-ebc048b02ab2   quay.io/osism/openvswitch-db-server:3.1.2.20230919         "dumb-init --single-…"   7 hours ago     Up 7 hours (healthy)                                   openvswitch_db
-4f33dfa66c14   hubblo/scaphandre:0.5.0                                    "scaphandre promethe…"   7 hours ago     Up 7 hours               10.10.129.64:9155->8080/tcp   scaphandre
-9b1f6342dc60   quay.io/osism/cron:3.0.20230919                            "dumb-init --single-…"   7 hours ago     Up 7 hours                                             cron
-718aecaddde1   quay.io/osism/kolla-toolbox:16.1.1.20230919                "dumb-init --single-…"   7 hours ago     Up 7 hours                                             kolla_toolbox
-f6f9422c1853   quay.io/osism/fluentd:4.5.1.20230919                       "dumb-init --single-…"   7 hours ago     Up 7 hours                                             fluentd
+CONTAINER ID   IMAGE                                                                                 COMMAND                  CREATED         STATUS                   PORTS                         NAMES
+559e5176695c   registry.osism.tech/kolla/release/2025.1/nova-compute:31.3.1.20260615                 "dumb-init --single-…"   5 minutes ago   Up 5 minutes (healthy)                                 nova_compute
+31248d71ab7d   registry.osism.tech/kolla/release/2025.1/nova-libvirt:10.0.0.20260615                 "dumb-init --single-…"   6 minutes ago   Up 6 minutes (healthy)                                 nova_libvirt
+9292030d706c   registry.osism.tech/kolla/release/2025.1/nova-ssh:31.3.1.20260615                     "dumb-init --single-…"   6 minutes ago   Up 6 minutes (healthy)                                 nova_ssh
+fda4b6fb30c8   registry.osism.tech/kolla/release/2025.1/neutron-metadata-agent:26.0.4.20260615       "dumb-init --single-…"   2 hours ago     Up 2 hours (healthy)                                   neutron_ovn_metadata_agent
+0e3ec450b668   registry.osism.tech/kolla/release/2025.1/ceilometer-compute:24.0.1.20260615           "dumb-init --single-…"   6 hours ago     Up 6 hours (healthy)                                   ceilometer_compute
+25ff9702e0e5   registry.osism.tech/kolla/release/2025.1/prometheus-libvirt-exporter:2.2.0.20260615   "dumb-init --single-…"   6 hours ago     Up 6 hours                                             prometheus_libvirt_exporter
+1bff2e29923b   registry.osism.tech/kolla/release/2025.1/prometheus-cadvisor:0.49.2.20260615          "dumb-init --single-…"   6 hours ago     Up 6 hours                                             prometheus_cadvisor
+602832daf237   registry.osism.tech/kolla/release/2025.1/prometheus-node-exporter:1.8.2.20260615      "dumb-init --single-…"   6 hours ago     Up 6 hours                                             prometheus_node_exporter
+d4de2f32cdf8   registry.osism.tech/kolla/release/2025.1/ovn-controller:25.3.1.20260615               "dumb-init --single-…"   6 hours ago     Up 6 hours                                             ovn_controller
+3bf43ae5a94f   registry.osism.tech/kolla/release/2025.1/openvswitch-vswitchd:3.5.1.20260615          "dumb-init --single-…"   7 hours ago     Up 7 hours (healthy)                                   openvswitch_vswitchd
+ebc048b02ab2   registry.osism.tech/kolla/release/2025.1/openvswitch-db-server:3.5.1.20260615         "dumb-init --single-…"   7 hours ago     Up 7 hours (healthy)                                   openvswitch_db
+4f33dfa66c14   hubblo/scaphandre:0.5.0                                                               "scaphandre promethe…"   7 hours ago     Up 7 hours               10.10.129.64:9155->8080/tcp   scaphandre
+9b1f6342dc60   registry.osism.tech/kolla/release/2025.1/cron:3.0.20260615                            "dumb-init --single-…"   7 hours ago     Up 7 hours                                             cron
+718aecaddde1   registry.osism.tech/kolla/release/2025.1/kolla-toolbox:20.4.1.20260615                "dumb-init --single-…"   7 hours ago     Up 7 hours                                             kolla_toolbox
+f6f9422c1853   registry.osism.tech/kolla/release/2025.1/fluentd:5.0.9.20260615                       "dumb-init --single-…"   7 hours ago     Up 7 hours                                             fluentd
 ```
 
 ## Remove a compute node

--- a/docs/guides/troubleshooting-guide/manager.md
+++ b/docs/guides/troubleshooting-guide/manager.md
@@ -64,23 +64,23 @@ of the ARA service.
    Depending on what the manager service looks like, this output may vary.
 
    ```console
-   NAME                             IMAGE                                        COMMAND                  SERVICE                CREATED              STATUS                        PORTS
-   ceph-ansible                     quay.io/osism/ceph-ansible:quincy            "/entrypoint.sh osis…"   ceph-ansible           About a minute ago   Up About a minute (healthy)
-   kolla-ansible                    quay.io/osism/kolla-ansible:2023.2           "/entrypoint.sh osis…"   kolla-ansible          About a minute ago   Up About a minute (healthy)
-   manager-api-1                    quay.io/osism/osism:latest                   "osism service api"      api                    About a minute ago   Up About a minute (healthy)   192.168.16.5:8000->8000/tcp
-   manager-ara-server-1             quay.io/osism/ara-server:latest              "sh -c '/wait && /ru…"   ara-server             About a minute ago   Up About a minute (healthy)   8000/tcp
-   manager-beat-1                   quay.io/osism/osism:latest                   "osism service beat"     beat                   About a minute ago   Up About a minute (healthy)
-   manager-conductor-1              quay.io/osism/osism:latest                   "osism worker conduc…"   conductor              About a minute ago   Up About a minute (healthy)
-   manager-flower-1                 quay.io/osism/osism:latest                   "osism service flower"   flower                 About a minute ago   Up About a minute (healthy)
-   manager-inventory_reconciler-1   quay.io/osism/inventory-reconciler:latest    "/sbin/tini -- /entr…"   inventory_reconciler   About a minute ago   Up About a minute (healthy)
-   manager-listener-1               quay.io/osism/osism:latest                   "osism service liste…"   listener               About a minute ago   Up About a minute (healthy)
-   manager-mariadb-1                index.docker.io/library/mariadb:11.3.2       "docker-entrypoint.s…"   mariadb                About a minute ago   Up About a minute (healthy)   3306/tcp
-   manager-netbox-1                 quay.io/osism/osism-netbox:latest            "osism worker netbox"    netbox                 About a minute ago   Up About a minute (healthy)
-   manager-openstack-1              quay.io/osism/osism:latest                   "osism worker openst…"   openstack              About a minute ago   Up About a minute (healthy)
-   manager-redis-1                  index.docker.io/library/redis:7.2.4-alpine   "docker-entrypoint.s…"   redis                  About a minute ago   Up About a minute (healthy)   6379/tcp
-   manager-watchdog-1               quay.io/osism/osism:latest                   "osism service watch…"   watchdog               About a minute ago   Up About a minute (healthy)
-   osism-ansible                    quay.io/osism/osism-ansible:latest           "/entrypoint.sh osis…"   osism-ansible          About a minute ago   Up About a minute (healthy)
-   osismclient                      quay.io/osism/osism:latest                   "sleep infinity"         osismclient            About a minute ago   Up About a minute
+   NAME                             IMAGE                                                   COMMAND                  SERVICE                CREATED              STATUS                        PORTS
+   ceph-ansible                     registry.osism.tech/osism/ceph-ansible:reef             "/entrypoint.sh osis…"   ceph-ansible           About a minute ago   Up About a minute (healthy)
+   kolla-ansible                    registry.osism.tech/osism/kolla-ansible:latest          "/entrypoint.sh osis…"   kolla-ansible          About a minute ago   Up About a minute (healthy)
+   manager-api-1                    registry.osism.tech/osism/osism:latest                  "osism service api"      api                    About a minute ago   Up About a minute (healthy)   192.168.16.5:8000->8000/tcp
+   manager-ara-server-1             registry.osism.tech/osism/ara-server:latest             "sh -c '/wait && /ru…"   ara-server             About a minute ago   Up About a minute (healthy)   8000/tcp
+   manager-beat-1                   registry.osism.tech/osism/osism:latest                  "osism service beat"     beat                   About a minute ago   Up About a minute (healthy)
+   manager-conductor-1              registry.osism.tech/osism/osism:latest                  "osism worker conduc…"   conductor              About a minute ago   Up About a minute (healthy)
+   manager-flower-1                 registry.osism.tech/osism/osism:latest                  "osism service flower"   flower                 About a minute ago   Up About a minute (healthy)
+   manager-inventory_reconciler-1   registry.osism.tech/osism/inventory-reconciler:latest   "/sbin/tini -- /entr…"   inventory_reconciler   About a minute ago   Up About a minute (healthy)
+   manager-listener-1               registry.osism.tech/osism/osism:latest                  "osism service liste…"   listener               About a minute ago   Up About a minute (healthy)
+   manager-mariadb-1                index.docker.io/library/mariadb:11.3.2                  "docker-entrypoint.s…"   mariadb                About a minute ago   Up About a minute (healthy)   3306/tcp
+   manager-netbox-1                 registry.osism.tech/osism/osism-netbox:latest           "osism worker netbox"    netbox                 About a minute ago   Up About a minute (healthy)
+   manager-openstack-1              registry.osism.tech/osism/osism:latest                  "osism worker openst…"   openstack              About a minute ago   Up About a minute (healthy)
+   manager-redis-1                  index.docker.io/library/redis:7.2.4-alpine              "docker-entrypoint.s…"   redis                  About a minute ago   Up About a minute (healthy)   6379/tcp
+   manager-watchdog-1               registry.osism.tech/osism/osism:latest                  "osism service watch…"   watchdog               About a minute ago   Up About a minute (healthy)
+   osism-ansible                    registry.osism.tech/osism/osism-ansible:latest          "/entrypoint.sh osis…"   osism-ansible          About a minute ago   Up About a minute (healthy)
+   osismclient                      registry.osism.tech/osism/osism:latest                  "sleep infinity"         osismclient            About a minute ago   Up About a minute
    ```
 
 7. When the manager service is healthy, the inventory and the fact cache


### PR DESCRIPTION
Container images are no longer pushed to Quay.io — see the *New container registry* section of the [OSISM 10 release notes](https://osism.tech/docs/release-notes/osism-10) — but two sample `docker ps` listings still showed images pulled from `quay.io/osism`. Those were the only `quay.io` occurrences left in the repository.

**`troubleshooting-guide/manager.md`** (manager containers) now shows `registry.osism.tech/osism`. Two tags of that listing do not exist on the new registry and are replaced with tags that do:

* `kolla-ansible:2023.2` → `kolla-ansible:latest`, matching the other images of that listing
* `ceph-ansible:quincy` → `ceph-ansible:reef`, the Ceph release OSISM defaults to

**`operations-guide/openstack/index.md`** (compute node containers) needed more than a registry swap. Kolla images now live in a namespace that carries the OpenStack version, so they move to `registry.osism.tech/kolla/release/2025.1` and the tags come from the 20260615 build that OSISM 10.1.0 pins, replacing the 20230919 build of the previous listing. `hubblo/scaphandre:0.5.0` is unchanged, it is not built by OSISM.

Every image reference of both listings — 24 including the Docker Hub ones that were already correct — was checked against the registry with a manifest request and resolves to an existing manifest. Nothing was pulled. markdownlint over both files is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)