### PR TITLE
repair broken gitlab no_proxy blog link

### DIFF
--- a/docs/guides/configuration-guide/proxy.md
+++ b/docs/guides/configuration-guide/proxy.md
@@ -30,7 +30,7 @@ but this can also lead to higher latencies or to inferred availability problems
 if the proxy is temporarily unavailable.
 
 :::warning
-As [Gitlab has described in 2021](https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/#no_proxy), there are subtle differences depending on the technology, implementation and age as to whether environment variables should be lowercase or uppercase, or what types of exclusions are possible.
+As [Gitlab has described](https://about.gitlab.com/blog/we-need-to-talk-no-proxy/), there are subtle differences depending on the technology, implementation and age as to whether environment variables should be lowercase or uppercase, or what types of exclusions are possible.
 
 Furthermore, the documentation of certain implementations is not very clear in its statements.
 


### PR DESCRIPTION
* it seems gitlab has removed the old article referenced before and has updated it in 2025
* assuming it has still more or less the same relevant context (which sounds to me like that), this replaces the link with the one to the updated article