### PR TITLE
Update MegaLinter from v9 to v10

### DIFF
--- a/.betterleaks.toml
+++ b/.betterleaks.toml
@@ -8,7 +8,10 @@ useDefault = true
 
 [[allowlists]]
 description = "Documentation example secrets — not real credentials"
-targetRules = ["generic-api-key"]
+# Keep this allowlist unscoped. A targetRules entry is silently dropped when
+# MegaLinter forwards EXCLUDED_DIRECTORIES, because it then wraps this file in a
+# generated config via "[extend] path" and rule-scoped allowlists do not survive
+# that merge. The regexes below are exact literals, so scoping adds nothing.
 regexes = [
   '''b9b6920d-e533-4728-8132-a5a0adfc24e5''',        # VNC console token in CLI output example
   '''AQBiHV9nAAAAABAAhtxl8rdW/EBvxiOGw4iMJw==''',     # Ceph keyring key example

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -57,7 +57,7 @@ jobs:
 
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/latest/flavors/
-        uses: oxsecurity/megalinter/flavors/documentation@v9
+        uses: oxsecurity/megalinter/flavors/documentation@v10
 
         id: ml
 

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -18,7 +18,6 @@ DISABLE_LINTERS:
   - COPYPASTE_JSCPD # we copy paste a lot of things to keep pages easy to read
   - CSS_STYLELINT # we focus on the documentation for now
   - ACTION_ZIZMOR # workflows use mutable tags; pinning to SHAs not adopted yet
-  - REPOSITORY_GITLEAKS # avoid false positives in documentation repo
   - REPOSITORY_GRYPE # not needed
   - REPOSITORY_TRIVY # not needed
   - REPOSITORY_TRIVY_SBOM # not needed


### PR DESCRIPTION
Updates the MegaLinter GitHub Action from `v9` to `v10`, together with the two configuration changes the new major version requires.

## What would have broken

I ran v9.6.0 and v10.0.0 side by side against identical clean clones of `main` (documentation flavor, `VALIDATE_ALL_CODEBASE=true`) to separate new failures from pre-existing ones.

**`REPOSITORY_BETTERLEAKS` failed the build on v10.** Both documented example secrets were reported as leaks — the VNC console token in `migration-vmware-esxi.md` and the Ceph keyring key in `ceph/index.mdx` — even though `.betterleaks.toml` allowlists them. Green on v9.6.0, red on v10.

The cause is v10's new forwarding of `EXCLUDED_DIRECTORIES` to linters that scan the workspace themselves. For betterleaks it stops passing our config directly and instead generates a wrapper that pulls ours in:

```toml
[extend]
path = '/tmp/lint/.betterleaks.toml'

[allowlist]
paths = ['\.git/', 'megalinter\-reports/']
```

Our allowlist regexes do survive that merge — but the `targetRules` binding to `generic-api-key` does not. I confirmed this by testing three shapes of the allowlist against a child config mimicking the generated one:

| Parent allowlist shape | Direct | Via generated wrapper |
| ---------------------- | ------ | --------------------- |
| `[[allowlists]]` + `targetRules` (previous) | pass | **2 leaks** |
| `[allowlist]` singular, no `targetRules` | pass | pass |
| `[[allowlists]]` plural, no `targetRules` | pass | pass |

The last two differ from the first by exactly one line, so `targetRules` is the culprit — not the plural/singular form and not allowlist merging in general. Dropping it fixes the failure and lets the forwarding stay enabled as v10 intends, rather than switching it off with `REPOSITORY_BETTERLEAKS_FORWARD_EXCLUDED_DIRECTORIES: false`.

**`REPOSITORY_GITLEAKS` no longer exists.** v10 removed it in favour of betterleaks and prints a notice on every run for configurations still referencing it. The migration itself was already done — `.betterleaks.toml` exists and betterleaks was already running under v9.6 — so only the stale `DISABLE_LINTERS` entry needed removing.

## On widening the allowlist scope

The two entries are exact literal strings, so restricting them to one rule added no real protection. To be sure detection is intact, I took the real Ceph key, mutated its last two payload characters, and betterleaks still reports it. Only the two exact documented literals are exempt.

The alternative was a `.gitleaksignore` with fingerprints, which does work under v10's defaults, but each entry pins a line number: inserting two lines above the example in `ceph/index.mdx` brought the leak straight back. In a docs repo that would fail on unrelated PRs, so I did not go that way.

## Verification

Full v10 documentation-flavor run over the whole codebase with these changes: **exit 0, all 16 linters pass**, forwarding confirmed active for betterleaks, checkov and secretlint. The only remaining finding is the pre-existing, non-blocking lychee 404 on the GitLab `no_proxy` link in `proxy.md`, which is unrelated to this change.

## Two notes, no action needed here

- MegaLinter publishes images to **ghcr.io only** since v9.5.0. Local runs should pull `ghcr.io/oxsecurity/megalinter-documentation:v10`; Docker Hub has no v10 tag and its `v9` tag is frozen at 9.4.0. The Action reference used by the workflow is unaffected.
- v10 adds a default `LINTER_TIMEOUT_SECONDS: 300`. The slowest linter here is checkov at ~19s, so there is plenty of headroom; `SPELL_LYCHEE_TIMEOUT_SECONDS` is the knob if lychee ever gets slow in CI.

`targetRules` being silently ignored under `[extend]` looks like a betterleaks/gitleaks bug that MegaLinter's wrapping merely exposes. Happy to report it upstream if you think it is worth filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)