### PR TITLE
docs: cover macOS libssh and stale operator key

### DIFF
--- a/docs/guides/deploy-guide/seed.md
+++ b/docs/guides/deploy-guide/seed.md
@@ -66,9 +66,33 @@ present, set `SEED_CONTAINER=false` before running any playbook.
 
 ## Option 2: Manual installation
 
+On Ubuntu all required packages come from the archive:
+
 ```bash
 sudo apt-get install git python3-pip python3-virtualenv sshpass libssh-dev
 ```
+
+On macOS the equivalent packages come from Homebrew:
+
+```bash
+brew install libssh pkg-config
+```
+
+`libssh` is not optional here. The local venv installs `ansible-pylibssh`, and
+that package only ships wheels for Linux and for x86_64 macOS. On macOS with
+Apple Silicon there is no matching wheel, so `uv` falls back to the source
+distribution and compiles it, which fails with a missing `libssh` unless the
+library and its headers are present. If the build still does not find them,
+point it at the Homebrew prefix explicitly:
+
+```bash
+export CFLAGS="-I$(brew --prefix libssh)/include"
+export LDFLAGS="-L$(brew --prefix libssh)/lib"
+```
+
+The [seed container](#option-1-seed-container) avoids all of this, because the
+playbooks then run inside the image and nothing is built on the seed node. It is
+the recommended option on macOS.
 
 ## Get a copy of the configuration repository
 

--- a/docs/guides/operations-guide/operator_key_rotation.md
+++ b/docs/guides/operations-guide/operator_key_rotation.md
@@ -76,6 +76,17 @@ On the manager node:
   [...]
   ```
 * Commit and push the change to the repository.
+* In every checkout of the configuration repository that is used with
+  `environments/manager/run.sh` — the seed node, a workstation, the manager itself —
+  delete the operator private key that earlier runs left behind:
+  ```bash
+  rm -f environments/manager/id_rsa.operator
+  ```
+  `run.sh` writes this file from `operator_private_key` in `environments/secrets.yml`,
+  but only when it does not exist yet, and the file is listed in `.gitignore`. A copy
+  created before the rotation therefore survives every `git pull` unnoticed and
+  `run.sh` keeps authenticating with the old key. Removing it lets the next `run.sh`
+  write it again from the updated `secrets.yml`.
 
 ## Switching the manager to the new key
 

--- a/docs/guides/upgrade-guide/manager.mdx
+++ b/docs/guides/upgrade-guide/manager.mdx
@@ -106,6 +106,18 @@ are at the same commit by the time step 3 runs.
       [Option 2 of the seed chapter](../deploy-guide/seed.md#option-2-manual-installation)
       for the details. On macOS the seed container path is the easier route, since
       nothing is built locally then.
+    * `run.sh` authenticates against the manager with `environments/manager/id_rsa.operator`.
+      It writes that file from `operator_private_key` in `environments/secrets.yml`, but
+      only when it does not exist yet. The file is listed in `.gitignore`, so a copy from
+      an earlier run survives every `git pull` unnoticed. After the operator key has been
+      [rotated](../operations-guide/operator_key_rotation.md), delete the stale file so
+      that it is written again from `secrets.yml`, otherwise steps 2 and 3 keep offering
+      the old key and the SSH login fails:
+
+        ```bash
+        rm -f environments/manager/id_rsa.operator
+        ```
+
     * If Ansible Vault was used to encrypt `environments/manager/secrets.yml`, the vault
       password must be reachable. Its place in the configuration repository is
       `environments/.vault_pass`; `run.sh` finds that file on its own. It either contains

--- a/docs/guides/upgrade-guide/manager.mdx
+++ b/docs/guides/upgrade-guide/manager.mdx
@@ -98,6 +98,14 @@ are at the same commit by the time step 3 runs.
 
         </TabItem>
         </Tabs>
+    * Whenever the local venv path is used, the venv installs `ansible-pylibssh`, which
+      needs libssh on the machine that builds it. On Ubuntu this is `libssh-dev`. On
+      macOS with Apple Silicon there is no wheel for that package at all, so it is
+      compiled from source and the build fails with a missing `libssh` until
+      `brew install libssh pkg-config` has been run. See
+      [Option 2 of the seed chapter](../deploy-guide/seed.md#option-2-manual-installation)
+      for the details. On macOS the seed container path is the easier route, since
+      nothing is built locally then.
     * If Ansible Vault was used to encrypt `environments/manager/secrets.yml`, the vault
       password must be reachable. Its place in the configuration repository is
       `environments/.vault_pass`; `run.sh` finds that file on its own. It either contains


### PR DESCRIPTION
Two problems that came up while actually walking through the manager
upgrade guide. Both of them are in the local venv path of
`environments/manager/run.sh`.

### macOS: the venv build fails on a missing libssh

The venv installs `ansible-pylibssh`, and that package publishes wheels
only for Linux and for `x86_64` macOS — there is no `arm64` wheel. On
macOS with Apple Silicon `uv` therefore falls back to the source
distribution and compiles it, which fails on a missing `libssh`. The
seed chapter listed only the Ubuntu packages (`libssh-dev`), so the
Homebrew equivalent is added there, together with the `CFLAGS` /
`LDFLAGS` exports for the Homebrew prefix, and the upgrade guide points
at that section.

**I ran into this myself and worked out the fix by hand.** Installing the
two Homebrew packages was *not* enough on its own — the build only
started once `CFLAGS` and `LDFLAGS` were exported as well:

```bash
brew install libssh pkg-config
export CFLAGS="-I$(brew --prefix libssh)/include"
export LDFLAGS="-L$(brew --prefix libssh)/lib"
```

Worth deciding during review: the seed chapter currently presents the two
exports as a fallback ("if the build still does not find them"), but in
the run above they were required, so it may be better to promote them to
a normal part of the macOS steps.

Running the playbooks in the seed container avoids the build entirely, so
the docs now name that as the easier route on macOS.

### A stale `id_rsa.operator` survives an operator key rotation

`run.sh` authenticates against the manager with
`environments/manager/id_rsa.operator`. It writes that file from
`operator_private_key` in `environments/secrets.yml`, but
[only when the file does not exist yet](https://github.com/osism/generics/blob/main/environments/manager/run.sh).
Since `id_rsa.operator` is listed in `.gitignore`, a copy dropped there
by an earlier run survives every `git pull` unnoticed, and `run.sh` keeps
offering the revoked key after the operator key has been rotated. I hit
this after rotating my own key — the local checkout still had the old one
lying around.

This is now noted in the upgrade guide and added as an explicit step to
the operator key rotation guide.

### Alternative: fix the key generation instead

Documenting `rm -f environments/manager/id_rsa.operator` is a workaround
for what is arguably a bug in [osism/generics](https://github.com/osism/generics)
(`environments/manager/run.sh`). If `run.sh` regenerated the file
unconditionally, or compared it against `operator_private_key` and
rewrote it on a mismatch, the stale key could never be used in the first
place — and the note added here could be dropped from the docs again.
Happy to open an issue or a patch there if we prefer that route.

### Checks

- MegaLinter documentation flavor: `markdownlint` and `codespell` clean
  on all three files
- `yarn build` succeeds, so the new cross-guide links and the
  `#option-2-manual-installation` anchor resolve
- The two commits were verified to be independently consistent: the
  combined diff is identical to the original squashed change, and
  `markdownlint` is clean against the intermediate tree
