### PR TITLE
release-notes: document quorum queues default

### DIFF
--- a/docs/release-notes/osism-8.md
+++ b/docs/release-notes/osism-8.md
@@ -63,6 +63,44 @@ Release date: 17. January 2025
 
 * New `osism.services.teleport` role was added.
 
+### Upgrade notes
+
+#### RabbitMQ quorum queues
+
+The kolla default `om_enable_rabbitmq_quorum_queues` changed from `false` to `true` in the
+[defaults](https://github.com/osism/defaults) repository. It reaches a deployment through the
+`defaults_version` pinned by the release (`v0.20240924.0` in 8.0.2, `v0.20250113.0` in 8.1.0).
+
+**This new default is intended for new clusters, not for upgraded ones.** New deployments start
+with quorum queues from the beginning. For an existing deployment we recommend adding
+`om_enable_rabbitmq_quorum_queues: false` to the configuration before upgrading to OSISM 8.1 or
+OSISM 9. In configuration repositories created before this change the parameter is not present
+at all, so the new default takes effect unless it is set explicitly.
+
+Without the parameter, all OpenStack services receive `rabbit_quorum_queue = true` in the
+`[oslo_messaging_rabbit]` section of their configuration file and declare their RPC and
+notification queues as quorum queues instead of classic queues.
+
+:::warning
+The switch from classic queues to quorum queues was not tested for OSISM 8.1 and OSISM 9, a
+migration path for it was only developed for OSISM 10. An existing classic queue cannot be
+redeclared as a quorum queue, and the affected services fail as long as the old queues are
+still present. We therefore recommend setting the parameter explicitly to `false` before the
+upgrade.
+:::
+
+```yaml title="environments/kolla/configuration.yml"
+om_enable_rabbitmq_quorum_queues: false
+```
+
+The switch to quorum queues is supported with OSISM 10 as part of the
+[RabbitMQ 3 to RabbitMQ 4 migration](osism-10.md#rabbitmq-3-to-rabbitmq-4-migration).
+
+If you have already upgraded without setting the parameter and your queues have switched to
+quorum queues, leave them as they are. The OSISM 10 migration covers this case as well. The
+`osism migrate rabbitmq3to4` command that reports and performs the migration is only available
+in OSISM 10, there is no equivalent in OSISM 8 or OSISM 9.
+
 ## 8.0.2 (20241006)
 
 Release date: 6. October 2024

--- a/docs/release-notes/osism-9.md
+++ b/docs/release-notes/osism-9.md
@@ -98,6 +98,20 @@ playbooks.
 
 ## 9.0.0 (20250408)
 
+## RabbitMQ quorum queues
+
+Quorum queues have been the default since OSISM 8.1.0, so when upgrading from 8.0.x the change
+takes effect with this release. The default is intended for new clusters. For an existing
+deployment we recommend setting the parameter explicitly before the upgrade, as the switch to
+quorum queues was not tested for OSISM 9 and a migration path for it was only developed for
+OSISM 10.
+
+```yaml title="environments/kolla/configuration.yml"
+om_enable_rabbitmq_quorum_queues: false
+```
+
+See [RabbitMQ quorum queues](osism-8.md#rabbitmq-quorum-queues) for details.
+
 ## New container registry
 
 Container images are no longer pushed to Quay.io and are only made available on our own


### PR DESCRIPTION
It was reported that an upgrade from OSISM 8 to OSISM 9 switched all RabbitMQ queues from classic to quorum, and that this is not covered by our release notes.

## What changed

The parameter is `om_enable_rabbitmq_quorum_queues`. It was flipped from `false` to `true` in https://github.com/osism/defaults/pull/235 (commit `bf60e0f`, 2024-10-13), with the matching change in https://github.com/osism/cfg-cookiecutter/pull/674 one minute later. Neither commit carried a release note.

## Which release shipped it

Tracing `defaults_version` from the release manifests against the flag value in each `defaults` tag:

| Release | `defaults_version` | `om_enable_rabbitmq_quorum_queues` |
|:--------|:-------------------|:-----------------------------------|
| 8.0.2   | `v0.20240924.0`    | `false`                            |
| 8.1.0   | `v0.20250113.0`    | `true`                             |
| 9.0.0   | `v0.20250407.0`    | `true`                             |

So the default first shipped with **OSISM 8.1.0**, not 9.0.0. Deployments upgrading from 8.0.x to 9 cross it on that hop, which explains the report.

Configuration repositories created before October 2024 do not carry the parameter at all, so they pick up the new default silently. `testbed/environments/kolla/configuration.yml` still pins `false`, so CI never exercised the transition.

## What this adds

* An `Upgrade notes` subsection in the 8.1.0 release notes stating that the new default is intended for new clusters, not for upgraded ones, with the recommendation to set the parameter explicitly to `false` before upgrading to 8.1 or 9. The switch was not tested for 8.1/9 and a migration path was only developed for OSISM 10, so the note points at the RabbitMQ 3 to RabbitMQ 4 migration and makes clear that `osism migrate rabbitmq3to4` only exists in OSISM 10.
* A pointer with the same recommendation in the 9.0.0 section, including the config snippet, so it also works for readers who only look at the OSISM 9 release notes.

## Verification

* MegaLinter v10 documentation flavor in Docker, markdown linters over all 168 files: clean, no fixes proposed.
* `yarn build` succeeds with `onBrokenLinks: 'throw'`, so both cross-file anchors resolve.

## Not included

`docs/concepts/technology-adaptability.md` still describes the old approach as "RabbitMQ 3 (classic queues)", which is inaccurate for 8.1/9 defaults. Left out to keep this change focused; happy to fold it in.